### PR TITLE
github-runners: use custom runner image

### DIFF
--- a/services/github-runners/runnerdeployment.yml
+++ b/services/github-runners/runnerdeployment.yml
@@ -29,6 +29,10 @@ spec:
       - ip: "10.20.64.86"
         hostnames:
           - "avatars.githubusercontent.com"
+      containers:
+      - name: runner
+        image: hub.deepin.com/deepincicd/github-runner-dind
+        imagePullPolicy: Always
 
 ---
 apiVersion: actions.summerwind.dev/v1alpha1
@@ -59,6 +63,10 @@ spec:
       - ip: "10.20.64.86"
         hostnames:
           - "avatars.githubusercontent.com"
+      containers:
+      - name: runner
+        image: hub.deepin.com/deepincicd/github-runner-dind
+        imagePullPolicy: Always
 
 ---
 apiVersion: actions.summerwind.dev/v1alpha1
@@ -69,7 +77,7 @@ spec:
   replicas: 2
   template:
     spec:
-      organization: peeweep-test
+      repository: peeweep-test/infra-settings
       hostAliases:
       - ip: "10.20.64.81"
         hostnames:
@@ -89,3 +97,7 @@ spec:
       - ip: "10.20.64.86"
         hostnames:
           - "avatars.githubusercontent.com"
+      containers:
+      - name: runner
+        image: hub.deepin.com/deepincicd/github-runner-dind
+        imagePullPolicy: Always


### PR DESCRIPTION
/cc @Zeno-sole @tsic404 


后续会考虑适配v23 beige直接当作github runner基础环境，同时也可以扩展v23 beige的用途（～=挖坑)