### PR TITLE
prow: update robot and plugin config

### DIFF
--- a/services/prow/config/config.yml
+++ b/services/prow/config/config.yml
@@ -70,6 +70,7 @@ tide:
     - approved
     excludedRepos:
     - deepin-community/template-repository
+    - deepin-community/rfcs
     missingLabels:
     - needs-rebase
     - do-not-merge/hold
@@ -83,7 +84,6 @@ tide:
     - linuxdeepin/dtkwidget
     - linuxdeepin/dtkdeclarative
     labels:
-    - lgtm
     - approved
     missingLabels:
     - do-not-merge/hold

--- a/services/prow/config/plugins.yml
+++ b/services/prow/config/plugins.yml
@@ -47,11 +47,6 @@ approve:
   - peeweep-test
   - deepin-community
   - linuxdeepin/dtk
-  - linuxdeepin/dtkcommon
-  - linuxdeepin/dtkcore
-  - linuxdeepin/dtkgui
-  - linuxdeepin/dtkwidget
-  - linuxdeepin/dtkdeclarative
   require_self_approval: true
   #lgtm_acts_as_approve: true
 triggers:


### PR DESCRIPTION
1. deepin-community/rcfs 项目取消自动合并
2. 去掉除linuxdeepin/dtk以外的dtk项目的approve插件支持，因为目前的使用场景为通过linuxdeepin/dtk项目触发批量更新changelog，也只需要该项目启用updatebot和approve插件