### PR TITLE
github-runners: runner controller add amd64 arch limit

### DIFF
--- a/services/github-runners/actions-runner-controller.yml
+++ b/services/github-runners/actions-runner-controller.yml
@@ -33833,6 +33833,8 @@ spec:
       labels:
         control-plane: controller-manager
     spec:
+      nodeSelector:
+        kubernetes.io/arch: amd64
       containers:
       - args:
         - --metrics-addr=127.0.0.1:8080


### PR DESCRIPTION
目前控制器只支持amd64,但是集群支持多架构,因此添加这个限制