### PR TITLE
obs: Add New Backend for deepin loong64 and riscv64 arch ports

### DIFF
--- a/services/obs/backend/backend-larv-pvc.yml
+++ b/services/obs/backend/backend-larv-pvc.yml
@@ -1,0 +1,23 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: obs
+
+---
+# Obs storage
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: backend-larv
+  namespace: obs
+  labels:
+    app: backend-larv
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: "obsbackend"
+  resources:
+    requests:
+      storage: 2600Gi
+  #volumeName: nfs-pv-obsbackend

--- a/services/obs/backend/backend-larv.yml
+++ b/services/obs/backend/backend-larv.yml
@@ -1,0 +1,992 @@
+---
+# Obs Backend Config ConfigMap
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: obs
+  name: backend-config-larv
+data:
+  BSConfig.pm: |
+    #
+    # Copyright (c) 2006, 2007 Michael Schroeder, Novell Inc.
+    #
+    # This program is free software; you can redistribute it and/or modify
+    # it under the terms of the GNU General Public License version 2 as
+    # published by the Free Software Foundation.
+    #
+    # This program is distributed in the hope that it will be useful,
+    # but WITHOUT ANY WARRANTY; without even the implied warranty of
+    # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    # GNU General Public License for more details.
+    #
+    # You should have received a copy of the GNU General Public License
+    # along with this program (see the file COPYING); if not, write to the
+    # Free Software Foundation, Inc.,
+    # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+    #
+    ################################################################
+    #
+    # Open Build Service Configuration
+    #
+
+    package BSConfig;
+
+    use Net::Domain;
+    use Socket;
+
+    my $hostname = Net::Domain::hostfqdn() || 'localhost';
+    # IP corresponding to hostname (only used for $ipaccess); fallback to localhost since inet_aton may fail to resolve at shutdown.
+    my $ip = quotemeta inet_ntoa(inet_aton($hostname) || inet_aton("localhost"));
+
+    my $frontend = 172.25.3.12; # FQDN of the WebUI/API server if it's not $hostname
+    my $src = 172.25.3.1;
+
+    # If defined, restrict access to the backend servers (bs_repserver, bs_srcserver, bs_service)
+    our $ipaccess = {
+      '.*' => 'rw',   # Permit IP of FQDN
+      "^10.42.*" => 'rw',
+      "^172.25.3.*" => 'rw',
+      '.*' => 'worker',   # build results can be delivered from any client in the network
+    };
+
+    # IP of the WebUI/API Server (only used for $ipaccess)
+    if ($frontend) {
+      my $frontendip = quotemeta inet_ntoa(inet_aton($frontend) || inet_aton("localhost"));
+      $ipaccess->{$frontendip} = 'rw' ; # in dotted.quad format
+      my $srcip = quotemeta inet_ntoa(inet_aton($src) || inet_aton("localhost"));
+      $ipaccess->{$srcip} = 'rw' ;
+    }
+
+    # Change also the SLP reg files in /etc/slp.reg.d/ when you touch hostname or port
+    our $srcserver = "http://172.25.3.1:5352";
+    our $reposerver = "http://backend-larv:5252";
+    our $serviceserver = "http://172.25.3.1:5152";
+    #our $clouduploadserver = "http://$hostname:5452"; 
+
+    # you can use different ports for worker connections
+    our $workersrcserver = "http://backend-larv:5352";
+    our $workerreposerver = "http://backend-larv:5252";
+
+    #our $servicedir = "/usr/lib/obs/service/";
+    #our $servicetempdir = "/srv/obs/service";
+    #our $serviceroot = "/opt/obs/MyServiceSystem";
+
+    # Maximum number of concurrent jobs for source service
+    #our $service_maxchild = 20;
+
+    # optional notification service:
+    #our $hermesserver = "http://$hostname/hermes";
+    #our $hermesnamespace = "OBS";
+    #
+    # Notification Plugin, multiple plugins supported, separated by space
+    #our $notification_plugin = "notify_hermes notify_rabbitmq";
+    #
+
+    # Package defaults
+    our $bsdir = '/srv/obs';
+    our $bsuser = 'obsrun';
+    our $bsgroup = 'obsrun';
+    # user and group for bs_service (if the lxc service wrapper is used, set
+    # $bsserviceuser to root). If several obs services (e.g., bs_service and
+    # bs_srcserver) run on the same host, make sure that $bsservicegroup is set
+    # to $bsgroup.
+    our $bsserviceuser = 'obsservicerun';
+    our $bsservicegroup = $bsgroup;
+    #our $bsquotafile = '/srv/obs/quota.xml';
+
+    # Use asynchronus scheduler. This avoids hanging schedulers on remote projects,
+    # when the network is slow or broken. This will become the default in future
+    # our $sched_asyncmode = 1;
+
+    # Define how the scheduler does a cold start. The default (0) is to request the
+    # data for all packages, (1) means that only the non-remote packages are fetched,
+    # (2) means that all of the package data fetches get delayed.
+    # our $sched_startupmode = 0;
+
+    # Disable fdatasync calls, increases the speed, but may lead to data 
+    # corruption on system crash when the filesystem does not guarantees
+    # data write before rename.
+    # It is esp. required on XFS filesystem.
+    # It is safe to be disabled on ext4 and btrfs filesystems.
+    #our $disable_data_sync = 1;
+
+    # Package rc script / backend communication + log files
+    our $rundir = "$bsdir/run";
+    our $logdir = "$bsdir/log";
+
+    # optional for non-acl systems, should be set for access control
+    # 0: trees are shared between projects (built-in default)
+    # 1: trees are not shared (only usable for new installations)
+    # 2: new trees are not shared, in case of a missing tree the shared
+    #    location is also tried (package default)
+    our $nosharedtrees = 2;
+
+    # enable binary release tracking by default for release projects
+    our $packtrack = [];
+
+    # optional: limit visibility of projects for some architectures
+    #our $limit_projects = {
+    # "ppc" => [ "openSUSE:Factory", "FATE" ],
+    # "ppc64" => [ "openSUSE:Factory", "FATE" ],
+    #};
+
+    # optional: allow seperation of releasnumber syncing per architecture
+    # one counter pool for all ppc architectures, one for i586/x86_64,
+    # arm archs are seperated and one for the rest in this example
+    our $relsync_pool = {
+    "local" => "local",
+    "i586" => "i586",
+    "x86_64" => "i586",
+    "ppc" => "ppc",
+    "ppc64" => "ppc",
+    "ppc64le" => "ppc",
+    "mips" => "mips",
+    "mips64" => "mips",
+    "mipsel" => "mipsel",
+    "mips64el" => "mipsel",
+    "aarch64"  => "arm",
+    "aarch64_ilp32"  => "arm",
+    "armv4l"  => "arm",
+    "armv5l"  => "arm",
+    "armv6l"  => "arm",
+    "armv6hl" => "arm",
+    "armv7l"  => "arm",
+    "armv7hl" => "arm",
+    "armv5el" => "armv5el", # they do not exist
+    "armv6el" => "armv6el",
+    "armv7el" => "armv7el",
+    "armv8el" => "armv8el",
+    "sparcv9" => "sparcv9",
+    "sparc64" => "sparcv9",
+    };
+
+    our $redisserver = "redis://172.25.3.1:6379";
+
+    #No extra stage server sync
+    #our $stageserver = 'rsync://127.0.0.1/put-repos-main';
+    #our $stageserver = 'rsync://172.25.3.2/repo/';
+    #our $stageserver_sync = 'rsync://127.0.0.1/trigger-repos-sync';
+
+    #additional options for calling rsync in the publisher
+    #for example "--whole-file" if network faster than disk
+    #our $rsync_extra_options = "--whole-file";
+
+    #No package signing server
+    #our $sign = '/usr/bin/sign';
+    #Extend sign call with project name as argument "--project $NAME"
+    #our $sign_project = 1;
+    #Global sign key
+    #our $keyfile = '/srv/obs/openSUSE-Build-Service.asc';
+    #our $gpg_standard_key = "/etc/obs-default-gpg.asc";
+
+    # Use a special local arch for product building
+    # our $localarch = "x86_64";
+
+    # config options for the bs_worker
+    #
+    #our buildlog_maxsize = 500 * 1000000;
+    #our buildlog_maxidle =   8 * 3600;
+    #our xenstore_maxsize =  20 * 1000000;
+    #our gettimeout =         1 * 3600;
+    #
+    # run a script to check if the worker is good enough for the job
+    #our workerhostcheck = 'my_check_script';
+    #
+    # Allow to build as root, exceptions per package
+    # the keys are actually anchored regexes
+    # our $norootexceptions = { "my_project/my_package" => 1, "openSUSE:Factory.*/installation-images" => 1 };
+
+    # Use old style source service handling
+    # our $old_style_services = 1;
+
+    ###
+    # Optional support to split the binary backend. This can be used on large servers
+    # to seperate projects for better scalability.
+    # There is still just one source server, but there can be multiple servers which
+    # run each repserver, schedulers, dispatcher, warden and publisher
+    #
+    # This repo service is the 'home' server for all home:* projects. This and the
+    # $reposerver setting must be different on the binary backend servers.
+    our $partition = 'backend-larv';
+    #
+    # this defines how the projects are split. All home: projects are hosted
+    # on an own server in this example. Order is important.
+    # our $partitioning = [ 'home:' => 'home',
+    #                       '.*'    => 'main',
+    #                     ];
+    #
+    # our $partitionservers = { 'home' => 'http://home-backend-server:5252',
+    #                           'main' => 'http://main-backend-server:5252',
+    #                         };
+
+    # host specific configs
+    my $hostconfig = __FILE__;
+    $hostconfig =~ s/[^\/]*$/bsconfig.$hostname/;
+    if (-r $hostconfig) {
+      print STDERR "reading $hostconfig...\n";
+      require $hostconfig;
+    }
+
+    # For specific build constraints, for example to require a specific
+    # security level of the workers.
+    #
+    #our $dispatch_constraint = sub {
+    #  my ($job, $worker) = @_;
+    #
+    #  return 0 unless (grep {$_ eq "OBS_WORKER_SECURITY_LEVEL_1"} @{$worker->{'hostlabel'} || []});
+    #  return 1;
+    #}
+
+    # use createrepo_c instead of createrepo. This gets selected via update-alternatives usualy.
+    #our $createrepo = '/usr/bin/createrepo_c';
+    # use modifyrepo_c instead of modifyrepo
+    #our $modifyrepo = '/usr/bin/modifyrepo_c';
+
+    # enable service dispatcher
+    our $servicedispatch = 1;
+    # max of 4 parallel running services (default)
+    # our $servicedispatch_maxchild = 4;
+
+    # print all messages with a lower level than $debuglevel in addition to the normal log messages
+    #our $debuglevel = 1;
+
+    our $container_registries = {
+      'local' => {
+        server => $hostname,
+        pushserver => 'local:'
+      },
+    #   'staging-registry.example.com' => {
+    #     server => '',
+    #     user => '',
+    #     password => '',
+    #     repository_base => '',
+    #   },
+    #   'hub.docker.com' => {
+    #     server => '',
+    #     user => '',
+    #     password => '',
+    #     repository_base => '',
+    #   },
+    };
+
+    our $publish_containers = [
+    #   # key:   regex to match projid
+    #   # value: ArrayRef with identifiers for registries configured in $container_registries
+    #   'SUSE:.*'        => [ 'registry.example.com', 'hub.docker.com' ],
+    #   '.*:branches:.*' => [ 'staging-registry.example.com' ],
+      '.*'             => ['local'],
+    ];
+
+
+    # special options to use for starting containers in run-service-containerized
+    # our $docker_custom_opt = [];
+
+    ## Server where mirrored gems could be found - used in services like obs-service-bundle_gems
+    # our $gems_mirror = '';
+    #
+    ## Container which should be 'linked' when running "bundle_gems" service
+    # our $geminabox_container = '';
+    #
+
+    # public cloud uploader configuration
+    # our $cloudupload_pubkey = "/etc/obs/cloudupload/_pubkey"; # default setting
+
+    1;
+
+---
+# Obs Backend Server Config ConfigMap
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: obs
+  name: backend-server-config-larv
+data:
+  obs-server: |
+    #
+    # NOTE: all these options can be also declared in /etc/buildhost.config on each worker differently.
+    #
+
+    ## Path:        Applications/OBS
+    ## Description: The OBS backend code directory
+    ## Type:        string
+    ## Default:     ""
+    ## Config:      OBS
+    #
+    # An empty dir will lead to the fall back directory, typically /usr/lib/obs/server/
+    #
+    OBS_BACKENDCODE_DIR=""
+
+    ## Path:        Applications/OBS
+    ## Description: The base for OBS communication directory
+    ## Type:        string
+    ## Default:     ""
+    ## Config:      OBS
+    #
+    # An empty dir will lead to the fall back directory, typically /srv/obs/run
+    #
+    OBS_RUN_DIR=""
+
+    ## Path:        Applications/OBS
+    ## Description: The base for OBS logging directory
+    ## Type:        string
+    ## Default:     ""
+    ## Config:      OBS
+    #
+    # An empty dir will lead to the fall back directory, typically /srv/obs/log
+    #
+    OBS_LOG_DIR=""
+
+    ## Path:        Applications/OBS
+    ## Description: The base directory for OBS
+    ## Type:        string
+    ## Default:     ""
+    ## Config:      OBS
+    #
+    # An empty dir will lead to the fall back directory, typically /srv/obs
+    #
+    OBS_BASE_DIR=""
+
+    ## Path:        Applications/OBS
+    ## Description: Automatically setup api and webui for OBS server, be warned, this will replace config files !
+    ## Type:        ("yes" | "no")
+    ## Default:     "no"
+    ## Config:      OBS
+    #
+    # This is usally only enabled on the OBS Appliance
+    #
+    OBS_API_AUTOSETUP="yes"
+    #
+    # NOTE: all these options can be also declared in /etc/buildhost.config on each worker differently.
+    #
+
+    ## Path:        Applications/OBS
+    ## Description: define source server host to be used
+    ## Type:        string
+    ## Default:     ""
+    ## Config:      OBS
+    #
+    # An empty setting will point to localhost:5352 by default
+    #
+    OBS_SRC_SERVER=""
+
+    ## Path:        Applications/OBS
+    ## Description: define repository server host to be used
+    ## Type:        string
+    ## Default:     ""
+    ## Config:      OBS
+    #
+    # An empty setting will point to localhost:5252 by default
+    #
+    OBS_REPO_SERVERS=""
+
+    ## Path:        Applications/OBS
+    ## Description: define number of build instances
+    ## Type:        integer
+    ## Default:     0
+    ## Config:      OBS
+    #
+    # 0 instances will automatically use the number of CPU's
+    #
+    OBS_WORKER_INSTANCES="0"
+
+    ## Path:        Applications/OBS
+    ## Description: define names of build instances for z/VM
+    ## Type:        string
+    ## Default:     ""
+    ## Config:      OBS
+    #
+    # The names of the workers as defined in z/VM. These must have two minidisks
+    # assigned, and have a secondary console configured to the local machine: 
+    # 0150 is the root device
+    # 0250 is the swap device
+    #
+    #OBS_WORKER_INSTANCE_NAMES="LINUX075 LINUX076 LINUX077"
+    OBS_WORKER_INSTANCE_NAMES=""
+
+    ## Path:        Applications/OBS
+    ## Description: The base directory, where sub directories for each worker will get created
+    ## Type:        string
+    ## Default:     ""
+    ## Config:      OBS
+    #
+    #
+    OBS_WORKER_DIRECTORY=""
+
+    ## Path:        Applications/OBS
+    ## Description: The base for port numbers used by worker instances
+    ## Type:        integer
+    ## Default:     "0"
+    ## Config:      OBS
+    #
+    # 0 means let the operating system assign a port number
+    #
+    OBS_WORKER_PORTBASE="0"
+
+    ## Path:        Applications/OBS
+    ## Description: Number of parallel compile jobs per worker
+    ## Type:        integer
+    ## Default:     "1"
+    ## Config:      OBS
+    #
+    # this maps usually to "make -j1" during build
+    #
+    OBS_WORKER_JOBS="1"
+
+    ## Path:        Applications/OBS
+    ## Description: Run in test mode (build results will be ignore, no job blocking)
+    ## Type:        ("yes" | "")
+    ## Default:     ""
+    ## Config:      OBS
+    #
+    OBS_WORKER_TEST_MODE=""
+
+    ## Path:        Applications/OBS
+    ## Description: define one or more labels for the build host.
+    ## Type:        string
+    ## Default:     ""
+    ## Config:      OBS
+    #
+    # A label can be used to build specific packages only on dedicated hosts.
+    # For example for benchmarking.
+    #
+    OBS_WORKER_HOSTLABELS=""
+
+    ## Path:        Applications/OBS
+    ## Description: can be used to define a security level of the worker
+    ## Type:        string
+    ## Default:     ""
+    ## Config:      OBS
+    #
+    # This will extend the hostlabels and can be used to limit the workers
+    # to the hosts which have all security fixes deployed.
+    #
+    OBS_WORKER_SECURITY_LEVEL=""
+
+    ## Path:        Applications/OBS
+    ## Description: Register in SLP server
+    ## Type:        ("yes" | "no")
+    ## Default:     "yes"
+    ## Config:      OBS
+    #
+    #
+    OBS_USE_SLP="yes"
+
+    ## Path:        Applications/OBS
+    ## Description: Use a common cache directory for downloaded packages
+    ## Type:        string
+    ## Default:     ""
+    ## Config:      OBS
+    #
+    # Enable caching requires a given directory here. Be warned, content will be
+    # removed there !
+    # 
+    OBS_CACHE_DIR=""
+
+    ## Path:        Applications/OBS
+    ## Description: Defines the package cache size
+    ## Type:        size in MB
+    ## Default:     ""
+    ## Config:      OBS
+    #
+    # Set the size to 50% of the maximum usable size of this partition
+    #
+    OBS_CACHE_SIZE=""
+
+    ## Path:        Applications/OBS
+    ## Description: Defines the nice level of running workers
+    ## Type:        integer
+    ## Default:     18
+    ## Config:      OBS
+    # 
+    # Nicenesses range from -20 (most favorable  scheduling) to 19 (least
+    # favorable).
+    # Default to 18 as some testsuites depend on being able to switch to
+    # one priority below (19) _and_ having changed the numeric level
+    # (so going from 19->19 makes them fail).
+    #
+    OBS_WORKER_NICE_LEVEL=18
+
+    ## Path:        Applications/OBS
+    ## Description: Set used VM type by worker
+    ## Type:        ("auto" | "xen" | "kvm" | "lxc" | "zvm" | "emulator:$arch" | "emulator:$arch:$script" | "qemu:$arch" | "none" | "openstack")
+    ## Default:     "auto"
+    ## Config:      OBS
+    #
+    #
+    OBS_VM_TYPE="auto"
+
+    ## Path:        Applications/OBS
+    ## Description: Set kernel used by worker (kvm)
+    ## Type:        ("none" | "/boot/vmlinuz" | "/foo/bar/vmlinuz)
+    ## Default:     "none"
+    ## Config:      OBS
+    #
+    # For z/VM this is normally /boot/image
+    #
+    OBS_VM_KERNEL="none"
+
+    ## Path:        Applications/OBS
+    ## Description: Set initrd used by worker (kvm)
+    ## Type:        ("none" | "/boot/initrd" | "/foo/bar/initrd-foo)
+    ## Default:     "none"
+    ## Config:      OBS
+    #
+    # for KVM, you have to create with (example for openSUSE 11.2):
+    #
+    # export rootfstype="ext4"
+    # mkinitrd -d /dev/null -m "ext4 binfmt_misc virtio_pci virtio_blk" -k vmlinuz-2.6.31.12-0.2-default -i initrd-2.6.31.12-0.2-default-obs_worker
+    #
+    # a working initrd file which includes virtio and binfmt_misc for OBS in order to work fine
+    #
+    # for z/VM, the build script will create a initrd at the given location if
+    # it does not yet exist.
+    # 
+    OBS_VM_INITRD="none"
+
+    ## Path:        Applications/OBS
+    ## Description: Autosetup for XEN/KVM/TMPFS disk (root) - Filesize in MB
+    ## Type:        integer
+    ## Default:     "4096"
+    ## Config:      OBS
+    #
+    #
+    OBS_VM_DISK_AUTOSETUP_ROOT_FILESIZE="4096"
+
+    ## Path:        Applications/OBS
+    ## Description: Autosetup for XEN/KVM disk (swap) - Filesize in MB
+    ## Type:        integer
+    ## Default:     "1024"
+    ## Config:      OBS
+    #
+    #
+    OBS_VM_DISK_AUTOSETUP_SWAP_FILESIZE="1024"
+
+    ## Path:        Applications/OBS
+    ## Description: Default filesystem to use for autosetup.
+    ## Type:        ("ext2" | "ext3" | "ext4" | "reiserfs" | "btrfs" | "xfs")
+    ## Default:     "ext3"
+    ## Config:      OBS
+    #
+    #
+    # Buildflag vmfstype may overwrite this for a specific job.
+    OBS_VM_DISK_AUTOSETUP_FILESYSTEM="ext3"
+
+    ## Path:        Applications/OBS
+    ## Description: Filesystem mount options to use for autosetup
+    ## Type:        string
+    ## Default:     ""
+    ## Config:      OBS
+    #
+    #
+    OBS_VM_DISK_AUTOSETUP_MOUNT_OPTIONS=""
+
+    ## Path:        Applications/OBS
+    ## Description: Enable build in memory
+    ## Type:        ("yes" | "")
+    ## Default:     ""
+    ## Config:      OBS
+    #
+    # WARNING: this requires much memory!
+    #
+    OBS_VM_USE_TMPFS=""
+
+    ## Path:        Applications/OBS
+    ## Description: Specify custom options for VM handler
+    ## Type:        string
+    ## Default:     ""
+    ## Config:      OBS
+    #
+    # Can be used to workaround problems with VM handler and should not be needed usually
+    #
+    OBS_VM_CUSTOM_OPTION=""
+
+    ## Path:        Applications/OBS
+    ## Description: Memory allocated for each VM (512) if not set
+    ## Type:        integer
+    ## Default:     ""
+    ## Config:      OBS
+    #
+    #
+    OBS_INSTANCE_MEMORY=""
+
+    ## Path:        Applications/OBS
+    ## Description: Enable storage auto configuration
+    ## Type:        ("yes" | "")
+    ## Default:     ""
+    ## Config:      OBS
+    #
+    # WARNING: this may destroy data on your hard disk !
+    # This is usually only used on mass deployed worker instances
+    #
+    OBS_STORAGE_AUTOSETUP=""
+
+    ## Path:        Applications/OBS
+    ## Description: Setup LVM via obsstoragesetup
+    ## Type:        ("take_all" | "use_obs_vg" | "none")
+    ## Default:     "use_obs_vg"
+    ## Config:      OBS
+    #
+    # take_all: WARNING: all LVM partitions will be used and all data erased !
+    # use_obs_vg:  A lvm volume group named "OBS" will be re-setup for the workers.
+    #
+    OBS_SETUP_WORKER_PARTITIONS="use_obs_vg"
+
+    ## Path:        Applications/OBS
+    ## Description: Size in MB when creating LVM partition for cache partition
+    ## Type:        integer
+    ## Default:     ""
+    ## Config:      OBS
+    #
+    #
+    OBS_WORKER_CACHE_SIZE=""
+
+    ## Path:        Applications/OBS
+    ## Description: Size in MB when creating LVM partition for each worker root partition
+    ## Type:        integer
+    ## Default:     ""
+    ## Config:      OBS
+    #
+    #
+    OBS_WORKER_ROOT_SIZE=""
+
+    ## Path:        Applications/OBS
+    ## Description: Size in MB when creating LVM partition for each worker swap partition
+    ## Type:        integer
+    ## Default:     ""
+    ## Config:      OBS
+    #
+    #
+    OBS_WORKER_SWAP_SIZE=""
+
+    ## Path:        Applications/OBS
+    ## Description: URL to a proxy service for caching binaries used by worker
+    ## Type:        string
+    ## Default:     ""
+    ## Config:      OBS
+    #
+    #
+    OBS_WORKER_BINARIES_PROXY=""
+
+    ## Path:        Applications/OBS
+    ## Description: URL to a ssh pub key to allow root user login
+    ## Type:        string
+    ## Default:     ""
+    ## Config:      OBS
+    #
+    # This is usually used on mass (PXE) deployed workers)
+    #
+    OBS_ROOT_SSHD_KEY_URL=""
+
+    ## Path:        Applications/OBS
+    ## Description: URL to a script to be downloaded and executed
+    ## Type:        string
+    ## Default:     ""
+    ## Config:      OBS
+    #
+    # This is a hook for doing special things in your setup at boot time
+    #
+    OBS_WORKER_SCRIPT_URL=""
+
+    ## Path:        Applications/OBS
+    ## Description: If chroot/lxc is used for build, empty it after build is finished
+    ## Type:        ("yes" | "")
+    ## Default:     ""
+    ## Config:      OBS
+    #
+    #
+    OBS_WORKER_CLEANUP_CHROOT=""
+
+    ##Path:         Application/OBS
+    ## Description: wipes the build environment of the worker after the build
+    ## Type:        ("yes" | "")
+    ## Default:     ""
+    ## Config:      OBS
+    #
+    #
+    OBS_WORKER_WIPE_AFTER_BUILD=""
+
+    ##Path:         Application/OBS
+    ## Description: name or id of openstack instance that controls the worker (building) instances
+    ## Type:        ("yes" | "")
+    ## Default:     ""
+    ## Config:      OBS
+    #
+    #
+    OBS_WORKER_CONTROL_INSTANCE=""
+
+    ##Path:         Application/OBS
+    ## Description: name or id flavor to create openstack worker (building) instance
+    ## Type:        ("yes" | "")
+    ## Default:     ""
+    ## Config:      OBS
+    #
+    #
+    OBS_WORKER_OS_FLAVOR=""
+
+    ##Path:         Application/OBS
+    ## Description: openstack environment variables. Only used when OBS_VM_TYPE=openstack
+    ## Type:        ("yes" | "")
+    ## Default:     ""
+    ## Config:      OBS
+    #
+    #
+    OS_AUTH_URL=""
+
+    OS_PROJECT_ID=""
+    OS_PROJECT_NAME=""
+    OS_USER_DOMAIN_NAME=""
+    OS_USERNAME=""
+    OS_PASSWORD=""
+    OS_REGION_NAME=""
+
+    OBS_WORKER_PREFIX=""
+
+    OBS_OPENSTACK_DISK_SIZE=""
+    OBS_OPENSTACK_SWAP_SIZE=""
+    OBS_OPENSTACK_MEMORY_SIZE=""
+
+    ## Path:        Applications/OBS
+    ## Description: define a malloc wrapper for scheduler
+    ## Type:        string
+    ## Default:     ""
+    ## Config:      OBS
+    #
+    # Define a wrapper script for preloading libs for scheduler startup
+    # "jemalloc.sh" is a possibility here after installing jemalloc package.
+    #
+    OBS_SCHEDULER_WRAPPER=""
+
+    ## Path:        Applications/OBS
+    ## Description: Enable copyin functionality during VM setup
+    ## Type:        ("yes" | "")
+    ## Default:     ""
+    ## Config:      OBS
+    #
+    # This enables mkfs copyin functionality support for some filesystems
+    #
+    OBS_WORKER_USE_MKFS_COPYIN=""
+
+    ## Path:        Applications/OBS
+    ## Description: Allow VMs to access the internet.
+    ## Type:        ("yes" | "")
+    ## Default:     ""
+    ## Config:      OBS
+    #
+    # yes: WARNING: this may not be safe and may prevent build reproductibility.
+    #
+    OBS_VM_ENABLE_NET=""
+
+---
+# Obs Backend Xml Config ConfigMap
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: obs
+  name: backend-xml-config-larv
+data:
+  configuration.xml: |
+    <configuration>
+      <title>OBS</title>
+      <tos_url></tos_url>
+      <description>Deepin OBS Instance</description>
+      <name>deepin-obs</name>
+      <anonymous>on</anonymous>
+      <registration>deny</registration>
+      <default_access_disabled>off</default_access_disabled>
+      <allow_user_to_create_home_project>on</allow_user_to_create_home_project>
+      <disallow_group_creation>off</disallow_group_creation>
+      <change_password>on</change_password>
+      <hide_private_options>off</hide_private_options>
+      <gravatar>on</gravatar>
+      <enforce_project_keys>off</enforce_project_keys>
+      <download_on_demand>on</download_on_demand>
+      <download_url>https://ci.deepin.org/repo/obs</download_url>
+      <obs_url>https://build.deepin.org</obs_url>
+      <admin_email>packages@deepin.org</admin_email>
+      <cleanup_empty_projects>on</cleanup_empty_projects>
+      <disable_publish_for_branches>on</disable_publish_for_branches>
+      <schedulers>
+        <arch>riscv64</arch>
+        <arch>loong64</arch>
+      </schedulers>
+      <unlisted_projects_filter>^home:.+</unlisted_projects_filter>
+      <unlisted_projects_filter_description>home projects</unlisted_projects_filter_description>
+    </configuration>
+
+---
+# Obs Backend Xml Config ConfigMap
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: obs
+  name: wg0-ci
+data:
+  wg0.conf: |
+    [Interface]
+    PrivateKey =
+    Address =
+    ListenPort =
+
+    [Peer]
+    PublicKey = 
+    Endpoint =
+    AllowedIPs =
+    PersistentKeepalive = 25
+
+    [Peer]
+    PublicKey =
+    Endpoint =
+    AllowedIPs =
+    PersistentKeepalive = 25
+
+---
+# Obs Backend Deployment
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: obs
+  name: backend-larv
+spec:
+  replicas: 1 # only 1
+  selector:
+    matchLabels:
+      app: obs-larv
+  template:
+    metadata:
+      labels:
+        app: obs-larv
+    spec:
+      nodeSelector:
+        nettype: optical-fiber
+      containers:
+      - name: backend-larv
+        image: hub.deepin.com/k3s/obs/backend:test
+        imagePullPolicy: Always
+        ports:
+        - name: backend-larv
+          containerPort: 5252
+        - name: src
+          containerPort: 5352
+        volumeMounts:
+        - name: backend-config-larv
+          mountPath: /usr/lib/obs/server/BSConfig.pm
+          subPath: BSConfig.pm
+        - name: backend-server-config-larv
+          mountPath: /etc/sysconfig/obs-server
+          subPath: obs-server
+        - name: backend-data
+          mountPath: /srv/obs
+        - name: backend-xml-config-larv
+          mountPath: /srv/obs/configuration.xml
+          subPath: configuration.xml
+        - name: wg0-ci
+          mountPath: /etc/wireguard/wg0.conf
+          subPath: wg0.conf
+        securityContext:
+          privileged: true
+          capabilities:
+            add:
+              - NET_ADMIN
+        env:
+        - name: SRCPORT
+          value: "5352"
+        - name: SRCIP
+          value: "172.25.3.1"
+        - name: BACKENDIP
+          value: "172.25.3.13"
+      volumes:
+      - name: backend-config-larv
+        configMap:
+          name: backend-config-larv
+          defaultMode: 420
+          items:
+          - key: BSConfig.pm
+            path: BSConfig.pm
+      - name: backend-server-config-larv
+        configMap:
+          name: backend-server-config-larv
+          defaultMode: 420
+          items:
+          - key: obs-server
+            path: obs-server
+      - name: backend-data
+        persistentVolumeClaim:
+          claimName: backend-larv
+      - name: backend-xml-config-larv
+        configMap:
+          name: backend-xml-config-larv
+          defaultMode: 420
+          items:
+          - key: configuration.xml
+            path: configuration.xml
+      - name: wg0-ci
+        configMap:
+          name: wg0-ci
+          defaultMode: 420
+          items:
+          - key: wg0.conf
+            path: wg0.conf
+      hostname: backend-larv
+      imagePullSecrets:
+      - name: deepinhub
+
+---
+# Obs Backend Service
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: obs
+  name: backend-larv
+spec:
+  selector:
+    app: obs-larv
+  ports:
+  - name: backend-larv
+    protocol: TCP
+    port: 5252
+    targetPort: 5252
+  - name: src
+    protocol: TCP
+    port: 5352
+    targetPort: 5352
+  type: ClusterIP
+
+---
+# Obs Backend Ingress
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  namespace: obs
+  name: obs
+  annotations:
+    # Change this to your issuer when using cert-manager. Does
+    # nothing when not using cert-manager.
+    cert-manager.io/cluster-issuer: letsencrypt-staging
+spec:
+  defaultBackend:
+    # specify the default backend for `ingress-gce` (https://cloud.google.com/kubernetes-engine/docs/concepts/ingress#default_backend)
+    service:
+      name: backend-larv
+      port:
+        number: 5252
+  rules:
+  - host: obs-backend-larv.deepin.org
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: backend-larv
+            port:
+              number: 5252
+  - host: obs-src-larv.deepin.org
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: backend-larv
+            port:
+              number: 5352


### PR DESCRIPTION
backen-larv-pvc.yml用于配置backend的存储

backend-larv.yml用于部署独立的backend服务,并使用ingress导出两个http端口访问:
1. obs-backend-larv.deepin.org backend仓库访问地址
2. obs-src-larv.deepin.org 与backend连接的源码访问