### PR TITLE
obs backend and worker config change

### DIFF
--- a/services/obs/backend/backend-larv.yml
+++ b/services/obs/backend/backend-larv.yml
@@ -819,7 +819,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   namespace: obs
-  name: wg0-ci
+  name: wg0-larv
 data:
   wg0.conf: |
     [Interface]
@@ -879,7 +879,7 @@ spec:
         - name: backend-xml-config-larv
           mountPath: /srv/obs/configuration.xml
           subPath: configuration.xml
-        - name: wg0-ci
+        - name: wg0-larv
           mountPath: /etc/wireguard/wg0.conf
           subPath: wg0.conf
         securityContext:
@@ -919,9 +919,9 @@ spec:
           items:
           - key: configuration.xml
             path: configuration.xml
-      - name: wg0-ci
+      - name: wg0-larv
         configMap:
-          name: wg0-ci
+          name: wg0-larv
           defaultMode: 420
           items:
           - key: wg0.conf

--- a/services/obs/worker/worker-ci.yml
+++ b/services/obs/worker/worker-ci.yml
@@ -125,7 +125,7 @@ data:
     #
     # 0 means let the operating system assign a port number
     #
-    OBS_WORKER_PORTBASE=32515
+    # OBS_WORKER_PORTBASE=32515
 
     ## Path:        Applications/OBS
     ## Description: Number of parallel compile jobs per worker
@@ -540,7 +540,7 @@ data:
     #
     # 0 means let the operating system assign a port number
 
-    OBS_WORKER_PORTBASE="32515"
+    # OBS_WORKER_PORTBASE="32515"
 
     ## Path:        Applications/OBS
     ## Description: Number of parallel compile jobs per worker
@@ -663,10 +663,6 @@ spec:
       - name: k3s-worker-ci-amd
         image: hub.deepin.com/k3s/obs/worker:latest
         imagePullPolicy: Always
-        ports:
-        - name: worker-port
-          containerPort: 32515
-          protocol: TCP
         volumeMounts:
         - name: server-config-ci
           mountPath: /etc/sysconfig/obs-server
@@ -733,10 +729,6 @@ spec:
       - name: k3s-worker-ci-arm
         image: hub.deepin.com/k3s/obs/worker:arm64-latest
         imagePullPolicy: Always
-        ports:
-        - name: worker-port
-          containerPort: 32515
-          protocol: TCP
         volumeMounts:
         - name: server-config-ci
           mountPath: /etc/sysconfig/obs-server


### PR DESCRIPTION
解决wiregurad网路配置冲突导致的worker节点挂到错误的backend的问题。