### PR TITLE
obs: fix debian i386 arch incorrect excluded when build

### DIFF
--- a/services/obs/src/Dockerfile
+++ b/services/obs/src/Dockerfile
@@ -33,6 +33,7 @@ RUN patch -p2 -d /usr/lib/obs/service/TarSCM/ < /patches/0001-obs-tar-scm.patch
 RUN patch -p2 -d /usr/lib/obs/service/TarSCM/ < /patches/0003-chore-remove-dpkg-parsechangelog-warning.patch
 # RUN patch -p3 -d /usr/lib/obs/server < /patches/0002-feat-Add-linglong-build-support.patch
 RUN tar xf /obs-server.tar -C /usr/lib/obs/; rm /obs-server.tar
+RUN patch -p1 -d /usr/lib/obs/server/build/ < /patches/0004-fix-debian-i386-arch-incorrect-excluded-when-build.patch
 
 WORKDIR /srv/obs/
 

--- a/services/obs/src/patches/0004-fix-debian-i386-arch-incorrect-excluded-when-build.patch
+++ b/services/obs/src/patches/0004-fix-debian-i386-arch-incorrect-excluded-when-build.patch
@@ -1,0 +1,23 @@
+From a11c1b23c0ce90b5b70c389ba8697a195e51f8e3 Mon Sep 17 00:00:00 2001
+From: hudeng <hudeng@deepin.org>
+Date: Wed, 11 Oct 2023 07:49:23 +0000
+Subject: [PATCH] fix: debian i386 arch incorrect  excluded when build
+
+---
+ Build/Deb.pm | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/Build/Deb.pm b/Build/Deb.pm
+index 45c93f0..ea2602b 100644
+--- a/Build/Deb.pm
++++ b/Build/Deb.pm
+@@ -35,6 +35,7 @@ eval {
+ };
+ 
+ my %obs2debian = (
++  "i386"    => "i386",
+   "i486"    => "i386",
+   "i586"    => "i386",
+   "i686"    => "i386",
+-- 
+2.35.3


### PR DESCRIPTION
need update obs src service image

log: