### PR TITLE
obs: api and src service scheduler add tolerations settings

### DIFF
--- a/services/obs/obs-cluster.yml
+++ b/services/obs/obs-cluster.yml
@@ -1809,6 +1809,11 @@ spec:
         - name: deepinhub
       nodeSelector:
         obs-type: src
+      tolerations:
+      - key: "node.kubernetes.io/unschedulable"
+        operator: "Equal"
+        value: ""
+        effect: "NoSchedule"
       restartPolicy: Always
       schedulerName: default-scheduler
       securityContext: {}
@@ -1919,6 +1924,11 @@ spec:
         - name: deepinhub
       nodeSelector:
         obs-type: src
+      tolerations:
+      - key: "node.kubernetes.io/unschedulable"
+        operator: "Equal"
+        value: ""
+        effect: "NoSchedule"
       restartPolicy: Always
       schedulerName: default-scheduler
       terminationGracePeriodSeconds: 30


### PR DESCRIPTION
api和src服务部署在集群中的外网节点,该节点因为带宽资源问题目前默认只运行这两个服务,因为通过服务调度器容忍 度现在其他集群中的服务调度到该节点

log: