### PR TITLE
prow: Add github-trigger-obs-ci for test manager obs ci by prow

### DIFF
--- a/services/prow/config/jobs/githubtriggerobsci.yml
+++ b/services/prow/config/jobs/githubtriggerobsci.yml
@@ -1,0 +1,76 @@
+presubmits:
+  peeweep-test:
+  - name: github-trigger-obs-ci
+    #cluster: test-infra-trusted
+    always_run: true
+    labels:
+      app: trigger-obs-ci
+    #decorate: true
+    #decoration_config:
+    #  timeout: 1h
+    spec:
+      nodeSelector:
+        kubernetes.io/arch: amd64
+      hostAliases:
+      - ip: "10.20.64.81"
+        hostnames:
+        - "github.com"
+      - ip: "10.20.64.82"
+        hostnames:
+        - "api.github.com"
+      - ip: "10.20.64.83"
+        hostnames:
+        - "github.githubassets.com"
+      - ip: "10.20.64.84"
+        hostnames:
+        - "raw.githubusercontent.com"
+      - ip: "10.20.64.85"
+        hostnames:
+        - "collector.github.com"
+      - ip: "10.20.64.86"
+        hostnames:
+        - "avatars.githubusercontent.com"
+      containers:
+      - name: branchprotector
+        image: hub.deepin.com/prow/githubtriggerobsci:latest
+        command:
+        - /entrypoint.sh
+        env:
+        - name: OSCUSER
+          valueFrom:
+            secretKeyRef:
+              name: obs-api-credential
+              key: username
+        - name: OSCPASS
+          valueFrom:
+            secretKeyRef:
+              name: obs-api-credential
+              key: password
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: obs-api-credential
+              key: github-token
+        - name: CONFIG_YAML_FILE
+          value: "/etc/config/config.yaml"
+        volumeMounts:
+        - name: github-token
+          mountPath: /etc/github
+          readOnly: true
+        - name: config
+          mountPath: /etc/config
+          readOnly: true
+      volumes:
+      - name: github-token
+        secret:
+          secretName: github-token
+      - name: config
+        configMap:
+          name: config
+    annotations:
+      testgrid-num-failures-to-alert: '6'
+      testgrid-alert-stale-results-hours: '12'
+      testgrid-dashboards: sig-deepin-cicd
+      testgrid-tab-name: trigger-obs-ci
+      testgrid-alert-email: hudeng@deepin.org
+      description: Runs Prow's trigger-obs-ci to config and trigger obs ci, and use canal return obs ci build job status.

--- a/services/prow/config/jobs/images/obsci/Dockerfile
+++ b/services/prow/config/jobs/images/obsci/Dockerfile
@@ -1,0 +1,20 @@
+FROM debian:latest
+
+ENV container docker
+
+# debian repository mirror settings
+RUN cp /etc/apt/sources.list.d/debian.sources /etc/apt/sources.list.d/debian.sources.bak; \
+  sed -i "s/deb.debian.org/mirrors.tuna.tsinghua.edu.cn/g" /etc/apt/sources.list.d/debian.sources; \
+  apt update
+
+RUN apt install -y yq curl; \
+  ln -s /usr/bin/xq-python /usr/bin/xq;
+  #sudo pip3 install -i https://pypi.tuna.tsinghua.edu.cn/simple xmltodict; \
+  #sudo pip3 install -i https://pypi.tuna.tsinghua.edu.cn/simple yq;
+
+
+ADD entrypoint.sh /entrypoint.sh
+
+RUN chmod 0755 /entrypoint.sh;
+
+#CMD ["/bin/bash", "/entrypoint.sh"]

--- a/services/prow/config/jobs/images/obsci/entrypoint.sh
+++ b/services/prow/config/jobs/images/obsci/entrypoint.sh
@@ -1,0 +1,212 @@
+#!/bin/sh
+#set -x
+
+# 导入yq命令
+command -v yq >/dev/null 2>&1 || { echo >&2 "yq命令未找到，请先安装yq命令"; exit 1; }
+command -v curl >/dev/null 2>&1 || { echo >&2 "curl命令未找到，请先安装curl命令"; exit 1; }
+
+#export
+
+# 检查Obs账户配置
+if [ -z "$OSCUSER" ]; then
+    echo "OBS User missing, exit"
+    exit -1
+fi
+
+if [ -z "$OSCPASS" ]; then
+    echo "OBS Password missing, exit"
+    exit -1
+fi
+
+# 定义YAML文件路径
+if [ -z "$CONFIG_YAML_FILE" ]; then
+    yaml_file="test.yml"
+else
+    yaml_file="$CONFIG_YAML_FILE"
+fi
+
+if [ -z "$REPO_OWNER" ]; then
+    export REPO_OWNER="linuxdeepin"
+fi
+
+if [ -z "$REPO_NAME" ]; then
+    export REPO_NAME="dtk"
+fi
+
+if [ -z "$PULL_NUMBER" ]; then
+    export PULL_NUMBER="1"
+fi
+
+if [ -z "$PULL_PULL_SHA" ]; then
+    export PULL_PULL_SHA="test1234"
+fi
+
+if [ -z "$PULL_HEAD_REF" ]; then
+    export PULL_HEAD_REF="master"
+fi
+
+export full_repo_name="$REPO_OWNER/$REPO_NAME"
+
+# 获取配置
+echo "Getting settings..."
+excluded=$(yq -e '.obscijobs' $yaml_file | yq --arg owner $REPO_OWNER  --arg repo $full_repo_name '.[] as $repos | select($repos.repos[] == $owner) | $repos.excluderepos[] | contains($repo)')
+if [ "${excluded}" = "true" ]; then
+    echo "$full_repo_name obs ci config excluded, skip and exit"
+    exit 0
+fi
+
+projectconfig=$(yq -e '.obscijobs' $yaml_file | yq --arg repo $full_repo_name '.[] as $repos | select($repos.repos[] == $repo) | $repos.project_config')
+if [ -z "$projectconfig" ]; then
+    projectconfig=$(yq -e '.obscijobs' $yaml_file | yq --arg repo $REPO_OWNER '.[] as $repos | select($repos.repos[] == $repo) | $repos.project_config')
+    echo "$full_repo_name obs ci project config isn't existed, using ${REPO_OWNER}'s config"
+    # exit 0
+fi
+
+if [ -z "$projectconfig" ]; then
+    echo "$REPO_OWNER obs ci project config isn't existed, using ${REPO_OWNER}'s config "
+    # exit 0
+fi
+#echo "projectconfig: $projectconfig"
+
+metaconfig=$(yq -e '.obscijobs' $yaml_file | yq --arg repo $full_repo_name '.[] as $repos | select($repos.repos[] == $repo) | $repos.project_meta_tpl')
+if [ -z "$metaconfig" ]; then
+    metaconfig=$(yq -e '.obscijobs' $yaml_file | yq --arg repo $REPO_OWNER '.[] as $repos | select($repos.repos[] == $repo) | $repos.project_meta_tpl')
+    echo "$full_repo_name obs ci meta config isn't existed, using ${REPO_OWNER}'s config"
+    # exit 0
+fi
+
+if [ -z "$metaconfig" ]; then
+    echo "$REPO_OWNER obs ci meta config isn't existed, skip and exit"
+    exit -1
+fi
+#echo "metaconfig: $metaconfig"
+
+packageconfig=$(yq -e '.obscijobs' $yaml_file | yq --arg repo $full_repo_name '.[] as $repos | select($repos.repos[] == $repo) | $repos.package_meta_tpl')
+if [ -z "$packageconfig" ]; then
+    packageconfig=$(yq -e '.obscijobs' $yaml_file | yq --arg repo $REPO_OWNER '.[] as $repos | select($repos.repos[] == $repo) | $repos.package_meta_tpl')
+    echo "$full_repo_name obs ci package config isn't existed, using ${REPO_OWNER}'s config"
+    # exit 0
+fi
+
+if [ -z "$packageconfig" ]; then
+    echo "$REPO_OWNER obs ci package config isn't existed, skip and exit"
+    exit -1
+fi
+#echo "packageconfig: $packageconfig"
+
+brconfig=$(yq -e '.obscijobs' $yaml_file | yq --arg repo $full_repo_name '.[] as $repos | select($repos.repos[] == $repo) | $repos.project_br_tpl')
+if [ -z "$brconfig" ]; then
+    brconfig=$(yq -e '.obscijobs' $yaml_file | yq --arg repo $REPO_OWNER '.[] as $repos | select($repos.repos[] == $repo) | $repos.project_br_tpl')
+    echo "$full_repo_name obs ci _branch_request config isn't existed, using ${REPO_OWNER}'s config"
+    # exit 0
+fi
+
+if [ -z "$brconfig" ]; then
+    echo "$REPO_OWNER obs ci _branch_request config isn't existed, skip and exit"
+    exit -1
+fi
+#echo "brconfig: $brconfig"
+
+serviceconfig=$(yq -e '.obscijobs' $yaml_file | yq --arg repo $full_repo_name '.[] as $repos | select($repos.repos[] == $repo) | $repos.project_service_tpl')
+if [ -z "$serviceconfig" ]; then
+    serviceconfig=$(yq -e '.obscijobs' $yaml_file | yq --arg repo $REPO_OWNER '.[] as $repos | select($repos.repos[] == $repo) | $repos.project_service_tpl')
+    echo "$full_repo_name obs ci service config isn't existed, using ${REPO_OWNER}'s config"
+    # exit 0
+fi
+
+if [ -z "$serviceconfig" ]; then
+    echo "$REPO_OWNER obs ci service config isn't existed, skip and exit"
+    exit -1
+fi
+#echo "serviceconfig: $serviceconfig"
+
+PROJECT_NAME="$REPO_OWNER:$REPO_NAME:Pr-$PULL_NUMBER"
+if [ "$PULL_HEAD_REF" = "topic-*" ]; then
+    prefix="topic-"
+    topic=${PULL_HEAD_REF#$prefix}
+    echo "Add to topic to $topic"
+    PROJECT_NAME="topics:$topic"
+fi
+
+metaconfig=${metaconfig#\"}
+echo ${metaconfig%\"} | sed 's/\\"/"/g' > meta.xml
+result=$(curl -u $OSCUSER:$OSCPASS "https://build.deepin.com/source/deepin:CI:$PROJECT_NAME/_meta"|grep "unknown_project")
+if [ "$result" != "" ];then
+    echo "Creating Obs CI project..."
+    sed -i "s#PROJECT_NAME#${PROJECT_NAME}#g" meta.xml
+    curl -X PUT -u "$OSCUSER:$OSCPASS" -H "Content-type: text/xml" -d @meta.xml "https://build.deepin.com/source/deepin:CI:$PROJECT_NAME/_meta"
+fi
+
+if [ "$projectconfig" != "" ]; then
+    echo "Project configuration"
+fi
+
+result=$(curl -u $OSCUSER:$OSCPASS "https://build.deepin.com/source/deepin:CI:$PROJECT_NAME/$REPO_NAME/_meta"|grep "unknown_package")
+#echo "\n********result: $result ********\n"
+if [ "$result" != "" ];then
+    echo "Creating Obs CI package..."
+    packageconfig=${packageconfig#\"}
+    echo ${packageconfig%\"} | sed 's/\\"/"/g' > meta1.xml
+    sed -i "s#PKGNAME#${REPO_NAME}#g" meta1.xml
+    sed -i "s#PROJECT_NAME#${PROJECT_NAME}#g" meta1.xml
+    curl -X PUT -u "$OSCUSER:$OSCPASS" -H "Content-type: text/xml" -d @meta1.xml "https://build.deepin.com/source/deepin:CI:$PROJECT_NAME/$REPO_NAME/_meta"
+fi
+
+# __branch_request文件中包含的sha值不变的情况下不重复提交
+# 减少source server的源码处理次数，节约有限的带宽
+oldsha=$(curl -u $OSCUSER:$OSCPASS "https://build.deepin.com/source/deepin:CI:$PROJECT_NAME/$REPO_NAME/_branch_request" | yq -e '.pull_request.head.sha')
+oldsha=${oldsha#\"}
+oldsha=${oldsha%\"}
+if [ "$oldsha" != "$PULL_PULL_SHA" ]; then
+    # 存在_service文件的情况下不重复提交
+    result=$(curl -u $OSCUSER:$OSCPASS "https://build.deepin.com/source/deepin:CI:$PROJECT_NAME/$REPO_NAME/_service"|grep "no such file")
+    if [ "$result" != "" ]; then
+        echo "Uploading _service..."
+        serviceconfig=${serviceconfig#\"}
+        echo ${serviceconfig%\"} | sed 's/\\"/"/g' > _service
+        sed -i "s#REPO#${REPO_OWNER}/${REPO_NAME}#g" _service
+        curl -X PUT -u "$OSCUSER:$OSCPASS" -H "Content-type: text/xml" -d @_service -s "https://build.deepin.com/source/deepin:CI:$PROJECT_NAME/$REPO_NAME/_service"
+    fi
+    echo "Uploading _branch_request..."
+    brconfig=${brconfig#\"}
+    echo ${brconfig%\"} | sed 's/\\"/"/g' > _branch_request
+    sed -i "s#REPO#${REPO_OWNER}/${REPO_NAME}#g" _branch_request
+    sed -i "s#TAGSHA#${PULL_PULL_SHA}#g" _branch_request
+    curl -X PUT -u "$OSCUSER:$OSCPASS" -d @_branch_request -s "https://build.deepin.com/source/deepin:CI:$PROJECT_NAME/$REPO_NAME/_branch_request"
+else
+    # 如果__branch_request的sha值未发生变化，触发rebuild，这里主要应对github通过'/test github-trigger-obs-ci'命令触发rebuild的场景
+    curl -X POST -u "$OSCUSER:$OSCPASS" "https://build.deepin.com/build/deepin:CI:$PROJECT_NAME?cmd=rebuild&package=$REPO_NAME"
+fi
+
+echo "Setting github commit status..."
+multirepos="true"
+repositories=$(cat meta.xml | xq -e '.project.repository[]."@name"')
+if [ $? -ne 0 ]; then
+    multirepos="false"
+    repositories=$(cat meta.xml | xq -e '.project.repository."@name"')
+fi
+
+for reponame in $repositories
+do
+    reponame=${reponame#\"}
+    reponame=${reponame%\"}
+    if [ $multirepos = "true" ]; then
+        arches=$(cat meta.xml | xq --arg reponame $reponame '.project.repository[] as $repos | select($repos."@name" == $reponame) | $repos.arch[]')
+    else
+        arches=$(cat meta.xml | xq --arg reponame $reponame '.project.repository as $repos | select($repos."@name" == $reponame) | $repos.arch[]')
+    fi
+    if [ $? -ne 0 ]; then
+        if [ $multirepos = "true" ]; then
+            arches=$(cat meta.xml | xq --arg reponame $reponame '.project.repository[] as $repos | select($repos."@name" == $reponame) | $repos.arch')
+        else
+            arches=$(cat meta.xml | xq --arg reponame $reponame '.project.repository as $repos | select($repos."@name" == $reponame) | $repos.arch')
+        fi
+    fi
+    for arch in $arches
+    do
+        arch=${arch#\"}
+        arch=${arch%\"}
+        echo "{\"state\":\"pending\", \"context\":\"OBS: ${reponame}/${arch}\", \"target_url\":\"https://build.deepin.com/package/live_build_log/deepin:CI:${PROJECT_NAME}/${REPO_NAME}/${reponame}/${arch}\"}" > status.data
+        curl -X POST -H "Accept: application/vnd.github+json" -H "Authorization: token $GITHUB_TOKEN" -d @status.data https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/statuses/${PULL_PULL_SHA}
+    done
+done

--- a/services/prow/config/jobs/images/obsci/test.yml
+++ b/services/prow/config/jobs/images/obsci/test.yml
@@ -1,0 +1,64 @@
+obscijobs:
+- repos:
+  - linuxdeepin
+  - deepin-community
+  - peeweep-test
+  project_config: |
+    ""
+  project_meta_tpl: |
+    <project name="deepin:CI:PROJECT_NAME">
+      <title/>
+      <description/>
+      <repository name="deepin_develop">
+        <path project="deepin:CI" repository="deepin_develop"/>
+        <arch>x86_64</arch>
+        <arch>aarch64</arch>
+      </repository>
+    </project>
+  package_meta_tpl: |
+    <package name="PKGNAME" project="deepin:CI:PROJECT_NAME">
+      <title/>
+      <description/>
+    </package>
+  project_br_tpl: '{"action":"opened","pull_request":{"head":{"repo":{"full_name":"REPO"},"sha":"TAGSHA"}}}'
+  project_service_tpl: |
+    <services>
+      <service name="obs_gbp">
+        <param name="url">https://github.com/REPO.git</param>
+        <param name="scm">git</param>
+        <param name="exclude">.git</param>
+        <param name="exclude">.github</param>
+        <param name="versionformat">@CHANGELOG@</param>
+        <param name="gbp-dch-release-update">enable</param>
+      </service>
+    </services>
+  excluderepos:
+    - linuxdeepin/dt
+- repos:
+  - hudeng-go
+  project_config: |
+    ""
+  project_meta_tpl: |
+    <project name="deepin:CI:PROJECT_NAME">
+      <title/>
+      <description/>
+      <repository name="deepin_develop">
+        <path project="deepin:CI" repository="deepin_develop"/>
+        <arch>x86_64</arch>
+        <arch>aarch64</arch>
+      </repository>
+    </project>
+  project_br_tpl: '{"action":"opened","pull_request":{"head":{"repo":{"full_name":"REPO"},"sha":"TAGSHA"}}}'
+  project_service_tpl: |
+    <services>
+      <service name="obs_gbp">
+        <param name="url">https://github.com/REPO.git</param>
+        <param name="scm">git</param>
+        <param name="exclude">.git</param>
+        <param name="exclude">.github</param>
+        <param name="versionformat">@CHANGELOG@</param>
+        <param name="gbp-dch-release-update">enable</param>
+      </service>
+    </services>
+  excluderepos:
+    - hudeng-go/test


### PR DESCRIPTION
测试状态,用于验证是否可以通过prow的github机器人接管obs ci构建任务,目前测试是可以的,但正式上线还 需要其他准备动作.

ps: obs ci迁移的prow的主要原因为方便扩展,从目前的维护经历来看,obs自导的scm工作流程与其内部其他服务耦合度 较高,直接修改比较困难,同时主线这部分功能已经发生非兼容性变动,更新部署维护都比较苦难,因此决定将该部分工作 迁移到prow的github门禁机器人,方便后续统一的门禁管理和维护

log: