### PR TITLE
obs: worker service hostname add 'k3s' prefix

### DIFF
--- a/services/obs/worker/entrypoint.sh
+++ b/services/obs/worker/entrypoint.sh
@@ -3,7 +3,7 @@
 # 修改hostname,使其包含obs 节点的名称
 OLDNAME=$(hostname)
 HOSTSUFFIX=$(hostname |awk -F '-' '{print $3"-"$5"-"$6}')
-export HOSTNAME="$NODENAME-$HOSTSUFFIX"
+export HOSTNAME="k3s-$NODENAME-$HOSTSUFFIX"
 echo "$HOSTNAME" > /proc/sys/kernel/hostname
 echo "$HOSTNAME" > /etc/hostname
 sed "s/$OLDNAME/$HOSTNAME/g" /etc/hosts >> /etc/hosts


### PR DESCRIPTION
用于区分物理构建节点和容器构建节点

log: