### PR TITLE
Fix obs ci

### DIFF
--- a/services/prow/config/jobs/githubtriggerobsci.yml
+++ b/services/prow/config/jobs/githubtriggerobsci.yml
@@ -2,7 +2,9 @@ presubmits:
   peeweep-test:
   - name: github-trigger-obs-ci
     #cluster: test-infra-trusted
-    always_run: true
+    decorate: false
+    always_run: false
+    skip_if_only_changed: "^.github/|^.obs/|^.reuse/|\\.(md|adoc)$|^(README|LICENSE)$"
     labels:
       app: trigger-obs-ci
     #decorate: true
@@ -31,7 +33,82 @@ presubmits:
         hostnames:
         - "avatars.githubusercontent.com"
       containers:
-      - name: branchprotector
+      - name: github-trigger-obs-ci
+        image: hub.deepin.com/prow/githubtriggerobsci:latest
+        command:
+        - /entrypoint.sh
+        env:
+        - name: OSCUSER
+          valueFrom:
+            secretKeyRef:
+              name: obs-api-credential
+              key: username
+        - name: OSCPASS
+          valueFrom:
+            secretKeyRef:
+              name: obs-api-credential
+              key: password
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: obs-api-credential
+              key: github-token
+        - name: CONFIG_YAML_FILE
+          value: "/etc/config/config.yaml"
+        volumeMounts:
+        - name: github-token
+          mountPath: /etc/github
+          readOnly: true
+        - name: config
+          mountPath: /etc/config
+          readOnly: true
+      volumes:
+      - name: github-token
+        secret:
+          secretName: github-token
+      - name: config
+        configMap:
+          name: config
+    annotations:
+      testgrid-num-failures-to-alert: '6'
+      testgrid-alert-stale-results-hours: '12'
+      testgrid-dashboards: sig-deepin-cicd
+      testgrid-tab-name: trigger-obs-ci
+      testgrid-alert-email: hudeng@deepin.org
+      description: Runs Prow's trigger-obs-ci to config and trigger obs ci, and use canal return obs ci build job status.
+
+  deepin-community:
+  - name: github-trigger-obs-ci
+    #cluster: test-infra-trusted
+    decorate: false
+    always_run: false
+    skip_if_only_changed: "^.github/|^.obs/|^.reuse/|\\.(md|adoc)$|^(README|LICENSE)$"
+    labels:
+      app: trigger-obs-ci
+    spec:
+      nodeSelector:
+        kubernetes.io/arch: amd64
+      hostAliases:
+      - ip: "10.20.64.81"
+        hostnames:
+        - "github.com"
+      - ip: "10.20.64.82"
+        hostnames:
+        - "api.github.com"
+      - ip: "10.20.64.83"
+        hostnames:
+        - "github.githubassets.com"
+      - ip: "10.20.64.84"
+        hostnames:
+        - "raw.githubusercontent.com"
+      - ip: "10.20.64.85"
+        hostnames:
+        - "collector.github.com"
+      - ip: "10.20.64.86"
+        hostnames:
+        - "avatars.githubusercontent.com"
+      containers:
+      - name: github-trigger-obs-ci
         image: hub.deepin.com/prow/githubtriggerobsci:latest
         command:
         - /entrypoint.sh

--- a/services/prow/config/jobs/images/obsci/entrypoint.sh
+++ b/services/prow/config/jobs/images/obsci/entrypoint.sh
@@ -49,8 +49,8 @@ export full_repo_name="$REPO_OWNER/$REPO_NAME"
 
 # 获取配置
 echo "Getting settings..."
-excluded=$(yq -e '.obscijobs' $yaml_file | yq --arg owner $REPO_OWNER  --arg repo $full_repo_name '.[] as $repos | select($repos.repos[] == $owner) | $repos.excluderepos[] | contains($repo)')
-if [ "${excluded}" = "true" ]; then
+excluded=$(yq -e '.obscijobs' $yaml_file | yq --arg owner $REPO_OWNER '.[] as $repos | select($repos.repos[] == $owner) | $repos.excluderepos[]' |grep $full_repo_name)
+if [  -n "${excluded}" ]; then
     echo "$full_repo_name obs ci config excluded, skip and exit"
     exit 0
 fi
@@ -120,8 +120,8 @@ if [ -z "$serviceconfig" ]; then
 fi
 #echo "serviceconfig: $serviceconfig"
 
-PROJECT_NAME="$REPO_OWNER:$REPO_NAME:Pr-$PULL_NUMBER"
-if [ "$PULL_HEAD_REF" = "topic-*" ]; then
+PROJECT_NAME="$REPO_OWNER:$REPO_NAME:PR-$PULL_NUMBER"
+if [[ "$PULL_HEAD_REF" == "topic-"* ]]; then
     prefix="topic-"
     topic=${PULL_HEAD_REF#$prefix}
     echo "Add to topic to $topic"

--- a/services/prow/config/jobs/images/obssrcsync/entrypoint.sh
+++ b/services/prow/config/jobs/images/obssrcsync/entrypoint.sh
@@ -58,8 +58,8 @@ curl -X POST -H "Authorization: Token $OBSTOKEN" "https://build.deepin.com/trigg
 PULL_NUMBER=$(curl -H "Accept: application/vnd.github+json" -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/commits/${PULL_BASE_SHA}/pulls |grep "\"number\":" |awk '{print $2}' |awk -F ',' '{print $1}')
 if [ "$PULL_NUMBER" != "" ]; then
     echo "Cleaning obs ci project..."
-    CI_PROJECT_NAME="$REPO_OWNER:$REPO_NAME:Pr-$PULL_NUMBER"
-    if [ "$PULL_HEAD_REF" = "topic-*" ]; then
+    CI_PROJECT_NAME="$REPO_OWNER:$REPO_NAME:PR-$PULL_NUMBER"
+    if [[ "$PULL_HEAD_REF" == "topic-"* ]]; then
         prefix="topic-"
         topic=${PULL_HEAD_REF#$prefix}
         CI_PROJECT_NAME="topics:$topic"

--- a/services/prow/config/jobs/obssrcsync.yml
+++ b/services/prow/config/jobs/obssrcsync.yml
@@ -1,8 +1,8 @@
 postsubmits:
-  peeweep-test:
+  deepin-community:
   - name: obs-src-sync
-    #cluster: test-infra-trusted
     always_run: true
+    decorate: false
     branches:
     - master
     labels:
@@ -30,7 +30,71 @@ postsubmits:
         hostnames:
         - "avatars.githubusercontent.com"
       containers:
-      - name: branchprotector
+      - name: obs-src-sync
+        image: hub.deepin.com/prow/obssrcsync:latest
+        command:
+        - /entrypoint.sh
+        env:
+        - name: OSCUSER
+          valueFrom:
+            secretKeyRef:
+              name: obs-api-credential
+              key: username
+        - name: OSCPASS
+          valueFrom:
+            secretKeyRef:
+              name: obs-api-credential
+              key: password
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: obs-api-credential
+              key: github-token
+        - name: OBSTOKEN
+          valueFrom:
+            secretKeyRef:
+              name: obs-api-credential
+              key: obs-token
+    annotations:
+      testgrid-num-failures-to-alert: '6'
+      testgrid-alert-stale-results-hours: '12'
+      testgrid-dashboards: sig-deepin-cicd
+      testgrid-tab-name: obs-src-sync
+      testgrid-alert-email: hudeng@deepin.org
+      description: Runs Prow obs-src-sync job to sync github pr merged code to obs.
+
+  peeweep-test:
+  - name: obs-src-sync
+    always_run: true
+    decorate: false
+    branches:
+    - master
+    labels:
+      app: obs-src-sync
+    spec:
+      nodeSelector:
+        kubernetes.io/arch: amd64
+      hostAliases:
+      - ip: "10.20.64.81"
+        hostnames:
+        - "github.com"
+      - ip: "10.20.64.82"
+        hostnames:
+        - "api.github.com"
+      - ip: "10.20.64.83"
+        hostnames:
+        - "github.githubassets.com"
+      - ip: "10.20.64.84"
+        hostnames:
+        - "raw.githubusercontent.com"
+      - ip: "10.20.64.85"
+        hostnames:
+        - "collector.github.com"
+      - ip: "10.20.64.86"
+        hostnames:
+        - "avatars.githubusercontent.com"
+      containers:
+      - name: obs-src-sync
         image: hub.deepin.com/prow/obssrcsync:latest
         command:
         - /entrypoint.sh


### PR DESCRIPTION
1. github-trigger-obs-ci解决topic场景下obs ci项目创建错误
2. github-trigger-obs-ci解决excluderepos配置不生效的问题
3. github-trigger-obs-ci运行添加过滤条件，部分ci相关以及文档相关文件更新不触发ci构建
4. obs-src-sync 修复名称错误
5. 在deepin-community组织中全局开启github-trigger-obs-ci、obs-src-sync任务