### PR TITLE
canal: Fix rabbitmq cluster start failed

### DIFF
--- a/services/canal/rabbitmq/apply.sh
+++ b/services/canal/rabbitmq/apply.sh
@@ -1,3 +1,3 @@
 helm repo add bitnami https://charts.bitnami.com/bitnami
 helm repo update
-helm -n canal upgrade --install rabbitmq-cluster bitnami/rabbitmq -f deepin-values.ym
+helm -n canal upgrade --install rabbitmq-cluster bitnami/rabbitmq -f deepin-values.yml

--- a/services/canal/rabbitmq/deepin-values.yml
+++ b/services/canal/rabbitmq/deepin-values.yml
@@ -264,7 +264,7 @@ clustering:
   ## forceBoot executes 'rabbitmqctl force_boot' to force boot cluster shut down unexpectedly in an unknown order
   ## ref: https://www.rabbitmq.com/rabbitmqctl.8.html#force_boot
   ##
-  forceBoot: false
+  forceBoot: true
   ## @param clustering.partitionHandling Switch Partition Handling Strategy. Either `autoheal` or `pause_minority` or `pause_if_all_down` or `ignore`
   ## ref: https://www.rabbitmq.com/partitions.html#automatic-handling
   ##
@@ -635,7 +635,7 @@ extraSecretsPrependReleaseName: false
 
 ## @param replicaCount Number of RabbitMQ replicas to deploy
 ##
-replicaCount: 2
+replicaCount: 5
 ## @param schedulerName Use an alternate scheduler, e.g. "stork".
 ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
 ##


### PR DESCRIPTION
rabbitmq集群在k3s集群节点异常的情况下同时掉线，会导致重新调度后启动失败
目前的解决办法是开启forceBoot=true选项，保证能正常启动，负作用为rabbitmq
可能会丢失掉部分消息，不过目前对业务影响不大，因此开启；同时，也增加的集群
的副本数量，进一步减少这种情况的概率