### PR TITLE
obs: backend and worker add clientip arg support

### DIFF
--- a/services/obs/backend/Dockerfile
+++ b/services/obs/backend/Dockerfile
@@ -37,6 +37,7 @@ RUN patch -p1 -d /usr/lib/obs/server/ < /patches/0006-feat-Add-loong64-support.p
 RUN patch -p1 -d /usr/lib/obs/server/BSDispatcher/ < /patches/0007-obs-backend-service-dispatcher-add-muti-worker-hostlabel-support.patch
 RUN patch -p1 -d /usr/lib/obs/server/build/ < /patches/0008-chore-obs-backend-build-dsc-script-add-eatmydata-support.patch
 RUN patch -p1 -d /usr/lib/obs/server/build/ < /patches/0009-obs-Add-deb-build-cmd-print.patch
+RUN patch -p1 -d /usr/lib/obs/server/ < /patches/0010-feat-obs-worker-add-clientip-arg-support.patch
 
 WORKDIR /srv/obs/
 

--- a/services/obs/backend/patches/0010-feat-obs-worker-add-clientip-arg-support.patch
+++ b/services/obs/backend/patches/0010-feat-obs-worker-add-clientip-arg-support.patch
@@ -1,0 +1,77 @@
+From adaf8ddf7caccb9d3b0f2b3595c94fff91bcd9c1 Mon Sep 17 00:00:00 2001
+From: hudeng <hudeng@deepin.org>
+Date: Wed, 3 Jan 2024 07:57:24 +0000
+Subject: [PATCH] feat: obs worker add clientip arg support
+
+---
+ bs_repserver | 5 +++--
+ bs_worker    | 9 ++++++++-
+ 2 files changed, 11 insertions(+), 3 deletions(-)
+
+diff --git a/bs_repserver b/bs_repserver
+index 1050dff..b99a431 100755
+--- a/bs_repserver
++++ b/bs_repserver
+@@ -1634,6 +1634,7 @@ sub workerstate {
+   die("cannot get your ip address\n") unless $peerip;
+   die("unsupported proto $peerproto\n") unless $peerproto eq 'http' || $peerproto eq 'https';
+   my $workerid = defined($cgi->{'workerid'}) ? $cgi->{'workerid'} : "$peerip:$peerport";
++  my $clientip = defined($cgi->{'clientip'}) ? $cgi->{'clientip'} : $peerip;
+   my $workerskel;
+   if (BSServer::have_content()) {
+     my $workerskelxml = BSServer::read_data(10000000);
+@@ -1679,9 +1680,9 @@ sub workerstate {
+     }
+     my $worker = {
+       'hostarch' => $harch,
+-      'ip' => $peerip,
++      'ip' => $clientip,
+       'port' => $peerport,
+-      'uri' => "$peerproto://$peerip:$peerport",
++      'uri' => "$peerproto://$clientip:$peerport",
+       'workerid' => $workerid,
+     };
+     $worker = { %$workerskel, %$worker } if $workerskel;
+@@ -4469,7 +4469,7 @@ my $dispatches = [
+   'POST:/worker cmd=checkconstraints $project $repository $arch $package' => \&checkconstraints,
+
+   # worker calls
+-  '!worker /worker $arch $port $state: workerid? working:bool? memory:num? disk:num? buildarch:arch* tellnojob:bool? proto:?' => \&workerstate,
++  '!worker /worker $arch $port $state: workerid? clientip:? working:bool? memory:num? disk:num? buildarch:arch* tellnojob:bool? proto:?' => \&workerstate,
+   '!worker /getbuildcode' => \&getbuildcode,
+   '!worker /getworkercode' => \&getworkercode,
+   '!worker POST:/putjob $arch $job $jobid $code:? now:num? kiwitree:bool? workerid?' => \&putjob,
+diff --git a/bs_worker b/bs_worker
+index 44a7479..7b9a460 100755
+--- a/bs_worker
++++ b/bs_worker
+@@ -94,6 +94,7 @@ my $vm_network;
+ my $emulator_script;
+ my $hugetlbfs;
+ my $workerid;
++my $clientip;
+ my $srcserver;
+ my @reposervers;
+ my $testmode;
+@@ -471,6 +472,11 @@ while (@ARGV) {
+     $workerid = shift @ARGV;
+     next;
+   }
++  if ($ARGV[0] eq '--clientip') {
++    shift @ARGV;
++    $clientip = shift @ARGV;
++    next;
++  }
+   if ($ARGV[0] eq '--test') {
+     shift @ARGV;
+     $testmode = 1;
+@@ -947,6 +953,7 @@ sub send_state {
+   my @args = ("state=$state", "arch=$ba", "port=$p");
+   push @args, "proto=$proto" if ($proto || 'http') ne 'http';
+   push @args, "workerid=$workerid" if defined $workerid;
++  push @args, "clientip=$clientip" if defined $clientip;
+   for my $server (@reposervers) {
+     next if $exclude && $server eq $exclude;
+     if ($state eq 'idle' && @reposervers > 1) {
+--
+2.35.3

--- a/services/obs/worker/Dockerfile
+++ b/services/obs/worker/Dockerfile
@@ -9,8 +9,8 @@ RUN zypper mr -da; zypper ar -cfg 'https://mirrors.tuna.tsinghua.edu.cn/opensuse
   zypper ar -cfg 'https://mirrors.tuna.tsinghua.edu.cn/opensuse/update/leap/$releasever/oss/' mirror-update; \
   zypper ar -cfg 'https://mirrors.tuna.tsinghua.edu.cn/opensuse/update/leap/$releasever/non-oss/' mirror-update-non-oss;
 
-RUN zypper ar -f -G https://download.opensuse.org/repositories/OBS:/Server:/Unstable/15.4/OBS:Server:Unstable.repo; \
-  zypper -n install obs-worker xz tar hostname ; zypper clean;
+RUN https_proxy=http://10.20.52.80:7890 zypper ar -f -G https://download.opensuse.org/repositories/OBS:/Server:/Unstable/15.4/OBS:Server:Unstable.repo; \
+  https_proxy=http://10.20.52.80:7890 zypper -n install obs-worker xz tar hostname patch; zypper clean;
 
 # setup obs-backend configuration
 RUN mkdir -p /srv/backup/; \
@@ -18,6 +18,10 @@ RUN mkdir -p /srv/backup/; \
 
 ADD config/obs-server /etc/sysconfig/obs-server
 ADD worker/config/obs-worker /etc/sysconfig/obs-worker
+COPY worker/patches /patches
+
+# apply some patches
+RUN patch -p1 -d /usr/sbin/ < /patches/0001-feat-obs-worker-add-clientip-arg-support.patch
 
 WORKDIR /srv/obs/
 

--- a/services/obs/worker/patches/0001-feat-obs-worker-add-clientip-arg-support.patch
+++ b/services/obs/worker/patches/0001-feat-obs-worker-add-clientip-arg-support.patch
@@ -1,0 +1,34 @@
+From 922b2ac5aa23b2d352adfa17168d1b4404f3bccf Mon Sep 17 00:00:00 2001
+From: hudeng <hudeng@deepin.org>
+Date: Thu, 4 Jan 2024 05:52:49 +0000
+Subject: [PATCH] feat: obs worker add clientip arg support
+
+---
+ obsworker | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/obsworker b/obsworker
+index 9f398fe..529ce82 100755
+--- a/obsworker
++++ b/obsworker
+@@ -80,6 +80,9 @@ fi
+ if [ -n "$OBS_WORKER_SECURITY_LEVEL" ]; then
+     OBS_WORKER_HOSTLABELS="OBS_WORKER_SECURITY_LEVEL_${OBS_WORKER_SECURITY_LEVEL} $OBS_WORKER_HOSTLABELS"
+ fi
++if [ -n "$OBS_CLIENT_IP" ]; then
++    OBS_CLIENTIP="--clientip $OBS_CLIENT_IP"
++fi
+
+ REPO_PARAM=
+ for i in $OBS_REPO_SERVERS; do
+@@ -482,7 +485,7 @@ case "$1" in
+                 MEMORY=
+             fi
+             echo "screen -t $WORKERID nice -n $OBS_NICE ./bs_worker --hardstatus $vmopt $port $proto --root $R" \
+-                "--statedir $workerdir/$I --id $WORKERID $REPO_PARAM $HUGETLBFS $HOSTLABELS" \
++                "--statedir $workerdir/$I --id $WORKERID $OBS_CLIENTIP $REPO_PARAM $HUGETLBFS $HOSTLABELS" \
+                 "$HOSTOWNER $OBS_JOBS $OBS_THREADS $OBS_TEST $OBS_WORKER_OPT $TMPFS $DEVICE $SWAP $MEMORY" \
+                 "$OBS_CLEANUP_CHROOT $OBS_WIPE_AFTER_BUILD $OBS_WORKER_USE_MKFS_COPYIN $ARCH $EMULATOR" \
+                 >> $screenrc
+--
+2.35.3


### PR DESCRIPTION
worker的配置文件中新增OBS_CLIENT_IP配置项,配合worker服务的启动脚本实现worker的ip配置化

目的是为了实现使用headscale服务链接的vpn网络中的远程节点可以接入obs