### PR TITLE
prow: add linuxdeepin/deepin-osconfig ci job config

### DIFF
--- a/services/prow/config/config.yml
+++ b/services/prow/config/config.yml
@@ -151,8 +151,6 @@ branch-protection:
           protect: false
         sig-deepin-pkg:
           protect: false
-        sig-deepin-sysdev-team:
-          protect: false
 
 tide:
   queries:
@@ -229,7 +227,7 @@ tide:
     deepin-community: rebase
     linuxdeepin: rebase
 
-decorate_all_jobs: true
+#decorate_all_jobs: true
 #periodics:
 #- interval: 1m
 #  agent: kubernetes
@@ -317,3 +315,34 @@ obscijobs:
   - deepin-community/.blog.deepin.org
   - deepin-community/infra-settings
   - deepin-community/deepin-chatopt-script
+- repos:
+  - linuxdeepin/deepin-osconfig
+  project_config: |
+    ""
+  project_meta_tpl: |
+    <project name="deepin:CI:PROJECT_NAME">
+      <title/>
+      <description/>
+      <repository name="deepin_develop">
+        <path project="deepin:CI" repository="deepin_develop"/>
+        <arch>x86_64</arch>
+        <arch>aarch64</arch>
+      </repository>
+    </project>
+  package_meta_tpl: |
+    <package name="PKGNAME" project="deepin:CI:PROJECT_NAME">
+      <title/>
+      <description/>
+    </package>
+  project_br_tpl: '{"action":"opened","pull_request":{"head":{"repo":{"full_name":"REPO"},"sha":"TAGSHA"}}}'
+  project_service_tpl: |
+    <services>
+      <service name="obs_gbp">
+        <param name="url">https://github.com/REPO.git</param>
+        <param name="scm">git</param>
+        <param name="exclude">.git</param>
+        <param name="exclude">.github</param>
+        <param name="versionformat">@CHANGELOG@</param>
+        <param name="gbp-dch-release-update">enable</param>
+      </service>
+    </services>

--- a/services/prow/config/jobs/githubtriggerobsci.yml
+++ b/services/prow/config/jobs/githubtriggerobsci.yml
@@ -167,3 +167,86 @@ presubmits:
       testgrid-tab-name: trigger-obs-ci
       testgrid-alert-email: hudeng@deepin.org
       description: Runs Prow trigger-obs-ci to config and trigger obs ci, and use canal return obs ci build job status.
+
+  linuxdeepin/deepin-osconfig:
+  - name: github-trigger-obs-ci
+    #cluster: test-infra-trusted
+    decorate: false
+    always_run: false
+    skip_if_only_changed: "^.github/|^.obs/|^.reuse/|\\.(md|adoc)$|^(README|LICENSE)$"
+    labels:
+      app: trigger-obs-ci
+    spec:
+      nodeSelector:
+        kubernetes.io/arch: amd64
+      hostAliases:
+      - ip: "10.20.64.81"
+        hostnames:
+        - "github.com"
+      - ip: "10.20.64.82"
+        hostnames:
+        - "api.github.com"
+      - ip: "10.20.64.83"
+        hostnames:
+        - "github.githubassets.com"
+      - ip: "10.20.64.84"
+        hostnames:
+        - "raw.githubusercontent.com"
+      - ip: "10.20.64.85"
+        hostnames:
+        - "collector.github.com"
+      - ip: "10.20.64.86"
+        hostnames:
+        - "avatars.githubusercontent.com"
+      - ip: "8.136.204.218"
+        hostnames:
+        - "build.deepin.com"
+      containers:
+      - name: github-trigger-obs-ci
+        image: hub.deepin.com/prow/githubtriggerobsci:latest
+        command:
+        - /entrypoint.sh
+        env:
+        - name: OSCUSER
+          valueFrom:
+            secretKeyRef:
+              name: obs-api-credential
+              key: username
+        - name: OSCPASS
+          valueFrom:
+            secretKeyRef:
+              name: obs-api-credential
+              key: password
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: obs-api-credential
+              key: github-token
+        - name: OBS_HOST
+          valueFrom:
+            secretKeyRef:
+              name: obs-api-credential
+              key: obs-host
+        - name: CONFIG_YAML_FILE
+          value: "/etc/config/config.yaml"
+        volumeMounts:
+        - name: github-token
+          mountPath: /etc/github
+          readOnly: true
+        - name: config
+          mountPath: /etc/config
+          readOnly: true
+      volumes:
+      - name: github-token
+        secret:
+          secretName: github-token
+      - name: config
+        configMap:
+          name: config
+    annotations:
+      testgrid-num-failures-to-alert: '6'
+      testgrid-alert-stale-results-hours: '12'
+      testgrid-dashboards: sig-deepin-cicd
+      testgrid-tab-name: trigger-obs-ci
+      testgrid-alert-email: hudeng@deepin.org
+      description: Runs Prow trigger-obs-ci to config and trigger obs ci, and use canal return obs ci build job status.

--- a/services/prow/config/jobs/obssrcsync.yml
+++ b/services/prow/config/jobs/obssrcsync.yml
@@ -142,3 +142,75 @@ postsubmits:
       testgrid-tab-name: obs-src-sync
       testgrid-alert-email: hudeng@deepin.org
       description: Runs Prow obs-src-sync job to sync github pr merged code to obs.
+
+  linuxdeepin/deepin-osconfig:
+  - name: obs-src-sync
+    always_run: true
+    decorate: false
+    branches:
+    - master
+    labels:
+      app: obs-src-sync
+    spec:
+      nodeSelector:
+        kubernetes.io/arch: amd64
+      hostAliases:
+      - ip: "10.20.64.81"
+        hostnames:
+        - "github.com"
+      - ip: "10.20.64.82"
+        hostnames:
+        - "api.github.com"
+      - ip: "10.20.64.83"
+        hostnames:
+        - "github.githubassets.com"
+      - ip: "10.20.64.84"
+        hostnames:
+        - "raw.githubusercontent.com"
+      - ip: "10.20.64.85"
+        hostnames:
+        - "collector.github.com"
+      - ip: "10.20.64.86"
+        hostnames:
+        - "avatars.githubusercontent.com"
+      - ip: "8.136.204.218"
+        hostnames:
+        - "build.deepin.com"
+      containers:
+      - name: obs-src-sync
+        image: hub.deepin.com/prow/obssrcsync:latest
+        command:
+        - /entrypoint.sh
+        env:
+        - name: OSCUSER
+          valueFrom:
+            secretKeyRef:
+              name: obs-api-credential
+              key: username
+        - name: OSCPASS
+          valueFrom:
+            secretKeyRef:
+              name: obs-api-credential
+              key: password
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: obs-api-credential
+              key: github-token
+        - name: OBSTOKEN
+          valueFrom:
+            secretKeyRef:
+              name: obs-api-credential
+              key: obs-token
+        - name: OBS_HOST
+          valueFrom:
+            secretKeyRef:
+              name: obs-api-credential
+              key: obs-host
+    annotations:
+      testgrid-num-failures-to-alert: '6'
+      testgrid-alert-stale-results-hours: '12'
+      testgrid-dashboards: sig-deepin-cicd
+      testgrid-tab-name: obs-src-sync
+      testgrid-alert-email: hudeng@deepin.org
+      description: Runs Prow obs-src-sync job to sync github pr merged code to obs.


### PR DESCRIPTION
添加默认的deepin的amd64和arm64构建任务。