### PR TITLE
obs: fix src service gbp archive error

### DIFF
--- a/services/obs/src/patches/0001-obs-tar-scm.patch
+++ b/services/obs/src/patches/0001-obs-tar-scm.patch
@@ -248,7 +248,7 @@ index 1a1ee78..1640414 100644
  
 +        # ignore debian directory
 +        with open(os.path.join(scm_object.clone_dir, ".git/info/attributes"), "a+") as f:
-+            f.write("./debian/ export-ignore\n")
++            f.write("/debian/ export-ignore\n")
 +
          #upstreamversion = version.split('-')[0]
          upstreamversion_end = version.rfind('-')


### PR DESCRIPTION
gbp和git更新后.gitattributes忽略目录的写法有所变化