### PR TITLE
prow: Add deepin orgs pr or issue lifecycle manage

### DIFF
--- a/services/prow/config/jobs/deepin-issueorpr-triage.yml
+++ b/services/prow/config/jobs/deepin-issueorpr-triage.yml
@@ -1,0 +1,48 @@
+periodics:
+- name: ci-triage-robot-close-prs
+  interval: 6h
+  decorate: true
+  annotations:
+    description: Closes rotten PRs after 90d of inactivity
+    testgrid-tab-name: close-prs
+  spec:
+    containers:
+    - image: hub.deepin.com/prow/commenter
+      command:
+      - commenter
+      args:
+      - |-
+        --query=org:linuxdeepin
+        org:deepin-community
+        org:peeweep-test
+        is:pr
+        -label:lifecycle/frozen
+        label:lifecycle/rotten
+      - --updated=2160h
+      - --token=/etc/github-token/token
+      - --endpoint=http://ghproxy
+      - |-
+        --comment=The Deepin project currently lacks enough active contributors to adequately respond to all issues and PRs.
+
+        This bot triages PRs according to the following rules:
+        - After 270d of inactivity, `lifecycle/stale` is applied
+        - After 90d of inactivity since `lifecycle/stale` was applied, `lifecycle/rotten` is applied
+        - After 90d of inactivity since `lifecycle/rotten` was applied, the PR is closed
+
+        You can:
+        - Reopen this PR with `/reopen`
+        - Mark this PR as fresh with `/remove-lifecycle rotten`
+        - Offer to help out with [Issue Triage][1]
+
+        /close
+
+      - --template
+      - --ceiling=10
+      - --confirm
+      volumeMounts:
+      - name: token
+        mountPath: /etc/github-token
+    volumes:
+    - name: token
+      secret:
+        secretName: github-token

--- a/services/prow/config/plugins.yml
+++ b/services/prow/config/plugins.yml
@@ -10,6 +10,7 @@ plugins:
     - approve
     - skip
     - topic
+    - lifecycle  # Allow /lifecycle stale
   deepin-community:
     plugins:
     - approve
@@ -29,6 +30,7 @@ plugins:
     - welcome
     - topic
     - skip
+    - lifecycle  # Allow /lifecycle stale
   peeweep-test:
     plugins:
     - approve
@@ -50,6 +52,7 @@ plugins:
     - project
     - topic
     - skip
+    - lifecycle  # Allow /lifecycle stale
 approve:
 - repos:
   - linuxdeepin/dtk


### PR DESCRIPTION
1. 添加lifecycle插件,支持通过命令行的方式开关pr和issue
2. 添加prow定期任务检查长期不活跃的pr和issue,并根据配置配合lifecycle插件关闭不活跃的pr

目前默认配置的是180天不活跃的pr先关闭。