### PR TITLE
Obs: backend and worker config update

### DIFF
--- a/services/obs/backend/Dockerfile
+++ b/services/obs/backend/Dockerfile
@@ -40,6 +40,12 @@ RUN patch -p1 -d /usr/lib/obs/server/build/ < /patches/0009-obs-Add-deb-build-cm
 RUN patch -p1 -d /usr/lib/obs/server/ < /patches/0010-feat-obs-worker-add-clientip-arg-support.patch
 RUN patch -p1 -d /usr/lib/obs/server/ < /patches/011-feat-Remove-backend-https-check.patch
 
+# add crontab support
+RUN https_proxy=http://10.20.52.80:7890 zypper install -y cron
+COPY backend/crontab /etc/cron.d/crontab
+COPY backend/cron-tasks.sh /cron-tasks.sh
+RUN chmod +x /cron-tasks.sh
+
 WORKDIR /srv/obs/
 
 VOLUME [ "/srv/obs/" ]

--- a/services/obs/backend/entrypoint.sh
+++ b/services/obs/backend/entrypoint.sh
@@ -4,8 +4,9 @@ set -x
 # link obs data directory for build and publish
 # /srv/obs-datas mount using separate storage, including the repos\build\jobs directory
 mkdir -p /srv/obs-datas/repos && if [ ! -d "/srv/obs/repos" ];then ln -sf /srv/obs-datas/repos /srv/obs/repos;fi
-mkdir -p /srv/obs-datas/build && if [ ! -d "/srv/obs/build" ];then ln -sf /srv/obs-datas/build /srv/obs/build;fi
+mkdir -p /srv/obs-datas/build/$(hostname) && if [ ! -d "/srv/obs/build" ];then ln -s /srv/obs-datas/build/$(hostname) /srv/obs/build;fi
 mkdir -p /srv/obs-datas/jobs/$(hostname) && if [ ! -d "/srv/obs/jobs" ];then ln -s /srv/obs-datas/jobs/$(hostname) /srv/obs/jobs;fi
+chown obsrun:obsrun /srv/obs-datas/build/$(hostname)
 chown -R obsrun:obsrun /srv/obs/jobs /srv/obs-datas/jobs/$(hostname)
 
 # Start obs backend services

--- a/services/obs/backend/entrypoint.sh
+++ b/services/obs/backend/entrypoint.sh
@@ -29,6 +29,8 @@ stop() {
 }
 
 # For auto restart
+/usr/sbin/logrotate /etc/logrotate.conf
+cron -n &
 while true
 do
     starting

--- a/services/obs/worker/worker-other.yml
+++ b/services/obs/worker/worker-other.yml
@@ -510,7 +510,7 @@ data:
     #
     #
 
-    OBS_REPO_SERVERS="http://backend-other:31262"
+    OBS_REPO_SERVERS="http://backend-other:5252"
 
     ## Path:        Applications/OBS
     ## Description: define number of build instances


### PR DESCRIPTION
1. 取消build目录共享，解决部分情况下共享的build数据被清理的问题
2. backend添加crontab和logrotate支持
3. backend other的worker配置更新，解决调度失败的问题

处理问题过程中发现一个obs调度的特性，即跨backend引用的project可以在当前backend进行调度和构建，例如backend ci引用了backend other的project(deepin:Develop:dde)，则该project还来不及在backend other上调度的情况下，backend-ci在调度该project并分配构建任务到该backend上，这种情况下共享/srv/obs/repos目录有风险，后续计划使用publish hook的方式聚合各个backend的/srv/obs/repos目录，而不是简单的进行该目录的共享，聚合过程的数据拷贝计划使用硬链接。