### PR TITLE
添加debian上游批量订阅处理流程

### DIFF
--- a/services/rsshub/.gitignore
+++ b/services/rsshub/.gitignore
@@ -1,0 +1,3 @@
+config/certs/*
+*log*
+*online*

--- a/services/rsshub/apply.sh
+++ b/services/rsshub/apply.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+kubectl create namespace rsshub
+helm repo add gabe565 https://charts.gabe565.com
+helm repo update
+helm -n rsshub install rsshub \
+  --set env.TZ="Asia/Shanghai" \
+    gabe565/rsshub -f deepin-values.yaml

--- a/services/rsshub/deepin-values.yaml
+++ b/services/rsshub/deepin-values.yaml
@@ -1,0 +1,56 @@
+#
+# IMPORTANT NOTE
+#
+# This chart inherits from our common library chart. You can check the default values/options here:
+# https://github.com/bjw-s/helm-charts/blob/a081de5/charts/library/common/values.yaml
+#
+# proxy: http://10.20.52.80:7890
+global:
+  imageRegistry: "hub.cicd.getdeepin.org"
+
+image:
+  # -- image repository
+  repository: diygod/rsshub
+  # -- image pull policy
+  pullPolicy: IfNotPresent
+  # -- image tag
+  tag: latest
+
+controller:
+  # -- Set the controller upgrade strategy
+  strategy: RollingUpdate
+
+# -- environment variables.
+# @default -- See [values.yaml](./values.yaml)
+env:
+  NODE_ENV: production
+
+# -- Configures service settings for the chart.
+# @default -- See [values.yaml](./values.yaml)
+service:
+  main:
+    ports:
+      http:
+        port: 1200
+
+ingress:
+  # -- Enable and configure ingress settings for the chart under this key.
+  # @default -- See [values.yaml](./values.yaml)
+  main:
+    enabled: false
+    # hosts:
+    #   - host: chart-example.local
+    #     paths:
+    #       - path: /
+    # tls:
+    #   - secretName: chart-example.local-tls
+    #     hosts:
+    #       - chart-example.local
+
+# -- Enable and configure redis subchart under this key.
+#    For more options see [redis chart documentation](https://github.com/bitnami/charts/tree/master/bitnami/redis)
+# @default -- See [values.yaml](./values.yaml)
+redis:
+  enabled: true
+  replica:
+    replicaCount: 1

--- a/services/rsshub/ttrss/feed-icons-pvc.yaml
+++ b/services/rsshub/ttrss/feed-icons-pvc.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    app: ttrss
+  name: ttrss-feed-icons
+  namespace: rsshub
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: "rsshub"
+  resources:
+    requests:
+      storage: 2Gi

--- a/services/rsshub/ttrss/forward/gotify/gotify-data-pvc.yml
+++ b/services/rsshub/ttrss/forward/gotify/gotify-data-pvc.yml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  annotations:
+    k8s.kuboard.cn/pvcType: Dynamic
+    pv.kubernetes.io/bind-completed: "yes"
+    pv.kubernetes.io/bound-by-controller: "yes"
+    volume.beta.kubernetes.io/storage-provisioner: nfs-rsshub
+    volume.kubernetes.io/storage-provisioner: nfs-rsshub
+  finalizers:
+  - kubernetes.io/pvc-protection
+  name: gotify-data
+  namespace: rsshub
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: rsshub

--- a/services/rsshub/ttrss/forward/gotify/gotify-deployment.yaml
+++ b/services/rsshub/ttrss/forward/gotify/gotify-deployment.yaml
@@ -1,0 +1,100 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    meta.helm.sh/release-name: gotify
+    meta.helm.sh/release-namespace: rsshub
+  labels:
+    app.kubernetes.io/instance: gotify
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: gotify
+    app.kubernetes.io/version: 2.4.0
+    helm.sh/chart: gotify-0.3.0
+    k8s.kuboard.cn/layer: cloud
+    k8s.kuboard.cn/name: gotify
+  name: gotify
+  namespace: rsshub
+  resourceVersion: '251257110'
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: gotify
+      app.kubernetes.io/name: gotify
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/instance: gotify
+        app.kubernetes.io/name: gotify
+    spec:
+      containers:
+        - env:
+            - name: TZ
+              value: Asia/Shanghai
+            - name: GOTIFY_DATABASE_DIALECT
+              value: sqlite3
+            - name: GOTIFY_DEFAULTUSER_NAME
+              value: admin
+            - name: GOTIFY_DEFAULTUSER_PASS
+              value: admin
+            - name: GOTIFY_PASSSTRENGTH
+              value: '10'
+            - name: GOTIFY_UPLOADEDIMAGESDIR
+              value: data/images
+            - name: GOTIFY_PLUGINSDIR
+              value: data/plugins
+            - name: GOTIFY_REGISTRATION
+              value: 'false'
+          image: 'gotify/server:2.4.0'
+          imagePullPolicy: Always
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /health
+              port: http
+              scheme: HTTP
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          name: gotify
+          ports:
+            - containerPort: 80
+              name: http
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /health
+              port: http
+              scheme: HTTP
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources: {}
+          securityContext: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /app/data
+              name: gotify-data
+      dnsPolicy: ClusterFirst
+      nodeSelector:
+        kubernetes.io/arch: amd64
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      serviceAccount: gotify
+      serviceAccountName: gotify
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - name: gotify-data
+          persistentVolumeClaim:
+            claimName: gotify-data

--- a/services/rsshub/ttrss/forward/matrix/gotify2matrix-conf-configmap.yml
+++ b/services/rsshub/ttrss/forward/matrix/gotify2matrix-conf-configmap.yml
@@ -1,0 +1,19 @@
+---
+apiVersion: v1
+data:
+  G2M_GOTIFY_DELETE_SENT: 'false'
+  G2M_GOTIFY_FORMAT_HTML: '"<h4>{{title}} (<u>{{app}}</u>)</h4>\n{{message}}"'
+  G2M_GOTIFY_FORMAT_PLAIN: '"{{title}} ({{app}}) \n{{message}}"'
+  G2M_GOTIFY_TOKEN: ClZREFYQleBKnDy
+  G2M_GOTIFY_URL: 'http://gotify-headless'
+  G2M_MATRIX_HOMESERVER: 'https://matrix.getdeepin.org'
+  G2M_MATRIX_PASSWORD:
+  G2M_MATRIX_ROOM_ID:
+  G2M_MATRIX_SESSION_DIR: /session
+  G2M_MATRIX_USERNAME: '@golf66:deepin.org'
+kind: ConfigMap
+metadata:
+  annotations: {}
+  labels: {}
+  name: gotify2matrix-conf
+  namespace: rsshub

--- a/services/rsshub/ttrss/forward/matrix/gotify2matrix-deployment.yml
+++ b/services/rsshub/ttrss/forward/matrix/gotify2matrix-deployment.yml
@@ -1,0 +1,54 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    k8s.kuboard.cn/displayName: ''
+  labels:
+    k8s.kuboard.cn/layer: svc
+    k8s.kuboard.cn/name: gotify2matrix-bot
+  name: gotify2matrix-bot
+  namespace: rsshub
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      k8s.kuboard.cn/layer: svc
+      k8s.kuboard.cn/name: gotify2matrix-bot
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        k8s.kuboard.cn/layer: svc
+        k8s.kuboard.cn/name: gotify2matrix-bot
+    spec:
+      containers:
+        - envFrom:
+            - configMapRef:
+                name: gotify2matrix-conf
+          image: larshaalck/gotify2matrix
+          imagePullPolicy: IfNotPresent
+          name: gotify-matrix-bot
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /session
+              name: gotify2matrix
+      dnsPolicy: ClusterFirst
+      nodeSelector:
+        kubernetes.io/arch: amd64
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - name: gotify2matrix
+          persistentVolumeClaim:
+            claimName: gotify2matrix

--- a/services/rsshub/ttrss/forward/matrix/gotify2matrix-pvc.yml
+++ b/services/rsshub/ttrss/forward/matrix/gotify2matrix-pvc.yml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    app: ttrss
+  name: gotify2matrix
+  namespace: rsshub
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: "rsshub"
+  resources:
+    requests:
+      storage: 1Gi

--- a/services/rsshub/ttrss/mercury-deployment.yaml
+++ b/services/rsshub/ttrss/mercury-deployment.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: ttrss-mercury
+  name: ttrss-mercury
+  namespace: rsshub
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ttrss-mercury
+  template:
+    metadata:
+      labels:
+        app: ttrss-mercury
+    spec:
+      containers:
+        - image: wangqiru/mercury-parser-api:latest
+          name: mercury
+      restartPolicy: Always

--- a/services/rsshub/ttrss/opencc-deployment.yaml
+++ b/services/rsshub/ttrss/opencc-deployment.yaml
@@ -1,0 +1,26 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: ttrss-opencc
+  name: ttrss-opencc
+  namespace: rsshub
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ttrss-opencc
+  template:
+    metadata:
+      labels:
+        app: ttrss-opencc
+    spec:
+      containers:
+        - env:
+            - name: NODE_ENV
+              value: production
+          image: wangqiru/opencc-api-server:latest
+          name: opencc
+      restartPolicy: Always
+      nodeSelector:
+        kubernetes.io/arch: amd64

--- a/services/rsshub/ttrss/plugin-gotify-pvc.yaml
+++ b/services/rsshub/ttrss/plugin-gotify-pvc.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    app: ttrss
+  name: plugin-gotify
+  namespace: rsshub
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: "rsshub"
+  resources:
+    requests:
+      storage: 1Gi

--- a/services/rsshub/ttrss/postgres-deployment.yaml
+++ b/services/rsshub/ttrss/postgres-deployment.yaml
@@ -1,0 +1,73 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations: {}
+  labels:
+    app: ttrss-postgres
+    k8s.kuboard.cn/layer: db
+    k8s.kuboard.cn/name: ttrss-postgres
+  name: ttrss-postgres
+  namespace: rsshub
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: ttrss-postgres
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: ttrss-postgres
+    spec:
+      containers:
+        - env:
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: password
+                  name: ttrss-db
+          image: 'postgres:13-alpine'
+          imagePullPolicy: IfNotPresent
+          name: postgres
+          ports:
+            - containerPort: 5432
+              name: pgport
+              protocol: TCP
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /var/lib/postgresql/data
+              name: ttrss-postgres-data
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      volumes:
+        - name: ttrss-postgres-data
+          persistentVolumeClaim:
+            claimName: ttrss-postgres-data
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {}
+  labels:
+    app: ttrss-postgres
+    k8s.kuboard.cn/layer: db
+    k8s.kuboard.cn/name: ttrss-postgres
+  name: ttrss-postgres
+  namespace: rsshub
+spec:
+  ports:
+    - name: pgsql-port
+      port: 5432
+      protocol: TCP
+      targetPort: 5432
+  selector:
+    app: ttrss-postgres
+  type: ClusterIP

--- a/services/rsshub/ttrss/postgres-pvc.yaml
+++ b/services/rsshub/ttrss/postgres-pvc.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    app: ttrss-postgres
+  name: ttrss-postgres-data
+  namespace: rsshub
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: "rsshub"
+  resources:
+    requests:
+      storage: 2Gi

--- a/services/rsshub/ttrss/ttrss-deployment.yaml
+++ b/services/rsshub/ttrss/ttrss-deployment.yaml
@@ -1,0 +1,122 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: ttrss
+    k8s.kuboard.cn/layer: web
+    k8s.kuboard.cn/name: ttrss
+  name: ttrss
+  namespace: rsshub
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: ttrss
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: ttrss
+    spec:
+      containers:
+        - env:
+            - name: DB_PASS
+              valueFrom:
+                secretKeyRef:
+                  key: password
+                  name: ttrss-db
+            - name: PGID
+              value: '1000'
+            - name: PUID
+              value: '1000'
+            - name: SELF_URL_PATH
+              value: 'https://rsshub.cicd.getdeepin.org'
+            - name: DB_HOST
+              value: ttrss-postgres
+          image: 'wangqiru/ttrss:nightly'
+          imagePullPolicy: Always
+          name: ttrss
+          ports:
+            - containerPort: 80
+              protocol: TCP
+          resources: {}
+          stdin: true
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          tty: true
+          volumeMounts:
+            - mountPath: /var/www/feed-icons
+              name: ttrss-feed-icons
+            - mountPath: /var/www/plugins.local/gotify_notifications
+              name: plugin-gotify
+      dnsPolicy: ClusterFirst
+      nodeSelector:
+        nettype: optical-fiber
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+      tolerations:
+        - effect: NoSchedule
+          key: node.kubernetes.io/unschedulable
+          operator: Exists
+      volumes:
+        - name: ttrss-feed-icons
+          persistentVolumeClaim:
+            claimName: ttrss-feed-icons
+        - name: plugin-gotify
+          persistentVolumeClaim:
+            claimName: plugin-gotify
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: ttrss
+    k8s.kuboard.cn/layer: web
+    k8s.kuboard.cn/name: ttrss
+  name: ttrss
+  namespace: rsshub
+spec:
+  internalTrafficPolicy: Cluster
+  ipFamilies:
+    - IPv4
+  ipFamilyPolicy: SingleStack
+  ports:
+    - name: ttrss-port
+      port: 80
+      protocol: TCP
+      targetPort: 80
+  selector:
+    app: ttrss
+  sessionAffinity: None
+  type: ClusterIP
+
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  labels:
+    app: ttrss
+    k8s.kuboard.cn/layer: web
+    k8s.kuboard.cn/name: ttrss
+  name: ttrss
+  namespace: rsshub
+spec:
+  ingressClassName: traefik
+  rules:
+    - host: ttrss.cicd.getdeepin.org
+      http:
+        paths:
+          - backend:
+              service:
+                name: ttrss
+                port:
+                  number: 80
+            path: /
+            pathType: Prefix


### PR DESCRIPTION
取消调用ttrss api的方式同步rss信息到matrix,通过https://github.com/deepin-community/.ttrss-plugin-gotify 插件转发消息到gotify消息中间件，然后添加gotify2matrix-bot机器人最终将消息转发给matrix。


ps: 取消ttrss api调用方式转发的原因为轮询的方式调用api获取大量rss信息会导致ttrss出现很大的性能问题，采用插件则不存在这个问题。