### PR TITLE
obs: src service add gbp scm cache support

### DIFF
--- a/services/obs/obs-cluster.yml
+++ b/services/obs/obs-cluster.yml
@@ -1780,6 +1780,9 @@ spec:
               protocol: TCP
             - containerPort: 30152
               protocol: TCP
+          env:
+            - name: CACHEDIRECTORY
+              value: /srv/obs/.cache
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/services/obs/src/src-data-pvc.yml
+++ b/services/obs/src/src-data-pvc.yml
@@ -13,4 +13,4 @@ spec:
   storageClassName: "obsbackend"
   resources:
     requests:
-      storage: 600Gi
+      storage: 1000Gi


### PR DESCRIPTION
1.增加obs数据盘的容量应对新增的cache数据
2.通过CACHEDIRECTORY环境变量开启gbp scm cache支持