### PR TITLE
Fix obs dns

### DIFF
--- a/services/obs/backend/backend-ci.yml
+++ b/services/obs/backend/backend-ci.yml
@@ -893,6 +893,10 @@ spec:
           - key: publish-hook.sh
             path: publish-hook.sh
       hostname: backend-ci
+      dnsConfig:
+        nameservers:
+          - 10.20.0.10
+      dnsPolicy: ClusterFirst
       imagePullSecrets:
       - name: deepinhub
 

--- a/services/obs/backend/backend-develop-main.yml
+++ b/services/obs/backend/backend-develop-main.yml
@@ -893,6 +893,10 @@ spec:
           - key: publish-hook.sh
             path: publish-hook.sh
       hostname: backend-develop-main
+      dnsConfig:
+        nameservers:
+          - 10.20.0.10
+      dnsPolicy: ClusterFirst
       imagePullSecrets:
       - name: deepinhub
 

--- a/services/obs/backend/backend-larv.yml
+++ b/services/obs/backend/backend-larv.yml
@@ -890,6 +890,10 @@ spec:
           - key: publish-hook.sh
             path: publish-hook.sh
       hostname: backend-larv
+      dnsConfig:
+        nameservers:
+          - 10.20.0.10
+      dnsPolicy: ClusterFirst
       imagePullSecrets:
       - name: deepinhub
 

--- a/services/obs/backend/backend-other.yml
+++ b/services/obs/backend/backend-other.yml
@@ -893,6 +893,10 @@ spec:
           - key: publish-hook.sh
             path: publish-hook.sh
       hostname: backend-other
+      dnsConfig:
+        nameservers:
+          - 10.20.0.10
+      dnsPolicy: ClusterFirst
       imagePullSecrets:
       - name: deepinhub
 

--- a/services/obs/backend/backend-test.yml
+++ b/services/obs/backend/backend-test.yml
@@ -890,6 +890,10 @@ spec:
           - key: publish-hook.sh
             path: publish-hook.sh
       hostname: backend-test
+      dnsConfig:
+        nameservers:
+          - 10.20.0.10
+      dnsPolicy: ClusterFirst
       imagePullSecrets:
       - name: deepinhub
 

--- a/services/obs/obs-cluster.yml
+++ b/services/obs/obs-cluster.yml
@@ -1804,6 +1804,9 @@ spec:
               name: servicedir
             - mountPath: /srv/obs/.cache
               name: cachedir
+      dnsConfig:
+        nameservers:
+          - 10.20.0.10
       dnsPolicy: ClusterFirst
       hostAliases:
         - hostnames:

--- a/services/obs/obs-cluster.yml
+++ b/services/obs/obs-cluster.yml
@@ -1982,7 +1982,11 @@ spec:
             - mountPath: /srv/www/obs/api/config/options.yml
               name: api-options-config
               subPath: options.yml
-      dnsPolicy: ClusterFirst
+      dnsConfig:
+        nameservers:
+          - 114.114.114.114
+          - 8.8.8.8
+      dnsPolicy: None
       imagePullSecrets:
         - name: deepinhub
       nodeSelector:

--- a/services/obs/worker/worker-ci.yml
+++ b/services/obs/worker/worker-ci.yml
@@ -708,6 +708,10 @@ spec:
         hostPath:
           path: /storage/OBS/obscache/
           type: DirectoryOrCreate
+      dnsConfig:
+        nameservers:
+          - 10.20.0.10
+      dnsPolicy: ClusterFirst
       imagePullSecrets:
       - name: deepinhub
 
@@ -780,5 +784,9 @@ spec:
         hostPath:
           path: /storage/OBS/obscache/
           type: DirectoryOrCreate
+      dnsConfig:
+        nameservers:
+          - 10.20.0.10
+      dnsPolicy: ClusterFirst
       imagePullSecrets:
       - name: deepinhub

--- a/services/obs/worker/worker-develop-main.yml
+++ b/services/obs/worker/worker-develop-main.yml
@@ -708,6 +708,10 @@ spec:
         hostPath:
           path: /storage/OBS/obscache/
           type: DirectoryOrCreate
+      dnsConfig:
+        nameservers:
+          - 10.20.0.10
+      dnsPolicy: ClusterFirst
       imagePullSecrets:
       - name: deepinhub
 
@@ -774,5 +778,9 @@ spec:
         hostPath:
           path: /storage/OBS/obscache/
           type: DirectoryOrCreate
+      dnsConfig:
+        nameservers:
+          - 10.20.0.10
+      dnsPolicy: ClusterFirst
       imagePullSecrets:
       - name: deepinhub

--- a/services/obs/worker/worker-other.yml
+++ b/services/obs/worker/worker-other.yml
@@ -702,6 +702,10 @@ spec:
         hostPath:
           path: /storage/OBS/obscache/
           type: DirectoryOrCreate
+      dnsConfig:
+        nameservers:
+          - 10.20.0.10
+      dnsPolicy: ClusterFirst
       imagePullSecrets:
       - name: deepinhub
 
@@ -768,5 +772,9 @@ spec:
         hostPath:
           path: /storage/OBS/obscache/
           type: DirectoryOrCreate
+      dnsConfig:
+        nameservers:
+          - 10.20.0.10
+      dnsPolicy: ClusterFirst
       imagePullSecrets:
       - name: deepinhub

--- a/services/obs/worker/worker-test.yml
+++ b/services/obs/worker/worker-test.yml
@@ -708,6 +708,10 @@ spec:
         hostPath:
           path: /storage/OBS/obscache/
           type: DirectoryOrCreate
+      dnsConfig:
+        nameservers:
+          - 10.20.0.10
+      dnsPolicy: ClusterFirst
       imagePullSecrets:
       - name: deepinhub
 
@@ -780,5 +784,9 @@ spec:
         hostPath:
           path: /storage/OBS/obscache/
           type: DirectoryOrCreate
+      dnsConfig:
+        nameservers:
+          - 10.20.0.10
+      dnsPolicy: ClusterFirst
       imagePullSecrets:
       - name: deepinhub


### PR DESCRIPTION
1. api服务切换运营商dns,加快obs web页面访问
2. 其他内网服务添加内网dns备份，防止集群dns炸掉后obs服务不可用。