### PR TITLE
obs: backend add binary proxy support

### DIFF
--- a/services/obs/backend/backend-ci.yml
+++ b/services/obs/backend/backend-ci.yml
@@ -848,6 +848,8 @@ spec:
         ports:
         - name: backend-port
           containerPort: 5252
+        - name: binproxy-port
+          containerPort: 5254
         volumeMounts:
         - name: backend-config-ci
           mountPath: /usr/lib/obs/server/BSConfig.pm
@@ -915,6 +917,10 @@ spec:
     protocol: TCP
     port: 5252
     targetPort: 5252
+  - name: binproxy-port
+    protocol: TCP
+    port: 5254
+    targetPort: 5254
   type: ClusterIP
 
 ---
@@ -937,5 +943,15 @@ spec:
                 name: backend-ci
                 port:
                   number: 5252
+            path: /
+            pathType: Prefix
+    - host: obs-backend-ci-binproxy.cicd.getdeepin.org
+      http:
+        paths:
+          - backend:
+              service:
+                name: backend-ci
+                port:
+                  number: 5254
             path: /
             pathType: Prefix

--- a/services/obs/backend/backend-develop-main.yml
+++ b/services/obs/backend/backend-develop-main.yml
@@ -848,6 +848,8 @@ spec:
         ports:
         - name: backend-port
           containerPort: 5252
+        - name: binproxy-port
+          containerPort: 5254
         volumeMounts:
         - name: backend-config-develop-main
           mountPath: /usr/lib/obs/server/BSConfig.pm
@@ -915,6 +917,10 @@ spec:
     protocol: TCP
     port: 5252
     targetPort: 5252
+  - name: binproxy-port
+    protocol: TCP
+    port: 5254
+    targetPort: 5254
   type: ClusterIP
 
 ---
@@ -937,5 +943,15 @@ spec:
                 name: backend-develop-main
                 port:
                   number: 5252
+            path: /
+            pathType: Prefix
+    - host: obs-backend-develop-main-binproxy.cicd.getdeepin.org
+      http:
+        paths:
+          - backend:
+              service:
+                name: backend-develop-main
+                port:
+                  number: 5254
             path: /
             pathType: Prefix

--- a/services/obs/backend/backend-larv.yml
+++ b/services/obs/backend/backend-larv.yml
@@ -845,6 +845,8 @@ spec:
         ports:
         - name: backend-port
           containerPort: 5252
+        - name: binproxy-port
+          containerPort: 5254
         volumeMounts:
         - name: backend-config-larv
           mountPath: /usr/lib/obs/server/BSConfig.pm
@@ -912,6 +914,10 @@ spec:
     protocol: TCP
     port: 5252
     targetPort: 5252
+  - name: binproxy-port
+    protocol: TCP
+    port: 5254
+    targetPort: 5254
   type: ClusterIP
 
 ---
@@ -934,5 +940,15 @@ spec:
                 name: backend-larv
                 port:
                   number: 5252
+            path: /
+            pathType: Prefix
+    - host: obs-backend-larv-binproxy.cicd.getdeepin.org
+      http:
+        paths:
+          - backend:
+              service:
+                name: backend-larv
+                port:
+                  number: 5254
             path: /
             pathType: Prefix

--- a/services/obs/backend/backend-other.yml
+++ b/services/obs/backend/backend-other.yml
@@ -848,6 +848,8 @@ spec:
         ports:
         - name: backend-port
           containerPort: 5252
+        - name: binproxy-port
+          containerPort: 5254
         volumeMounts:
         - name: backend-config-other
           mountPath: /usr/lib/obs/server/BSConfig.pm
@@ -915,6 +917,10 @@ spec:
     protocol: TCP
     port: 5252
     targetPort: 5252
+  - name: binproxy-port
+    protocol: TCP
+    port: 5254
+    targetPort: 5254
   type: ClusterIP
 
 ---
@@ -937,5 +943,15 @@ spec:
                 name: backend-other
                 port:
                   number: 5252
+            path: /
+            pathType: Prefix
+    - host: obs-backend-other-binproxy.cicd.getdeepin.org
+      http:
+        paths:
+          - backend:
+              service:
+                name: backend-other
+                port:
+                  number: 5254
             path: /
             pathType: Prefix

--- a/services/obs/worker/worker-ci.yml
+++ b/services/obs/worker/worker-ci.yml
@@ -639,6 +639,15 @@ data:
     #OBS_VM_USE_TMPFS="yes"
     #OBS_WORKER_TEST_MODE="yes"
 
+    ## Path:        Applications/OBS
+    ## Description: URL to a proxy service for caching binaries used by worker
+    ## Type:        string
+    ## Default:     ""
+    ## Config:      OBS
+    #
+    #
+    OBS_WORKER_BINARIES_PROXY="http://backend-ci:5254"
+
 ---
 # Obs Worker Amd64 StatefulSet
 apiVersion: apps/v1

--- a/services/obs/worker/worker-develop-main.yml
+++ b/services/obs/worker/worker-develop-main.yml
@@ -639,6 +639,15 @@ data:
     #OBS_VM_USE_TMPFS="yes"
     #OBS_WORKER_TEST_MODE="yes"
 
+    ## Path:        Applications/OBS
+    ## Description: URL to a proxy service for caching binaries used by worker
+    ## Type:        string
+    ## Default:     ""
+    ## Config:      OBS
+    #
+    #
+    OBS_WORKER_BINARIES_PROXY="http://backend-develop-main:5254"
+
 ---
 # Obs Worker Amd64 StatefulSet
 apiVersion: apps/v1

--- a/services/obs/worker/worker-other.yml
+++ b/services/obs/worker/worker-other.yml
@@ -639,6 +639,15 @@ data:
     #OBS_VM_USE_TMPFS="yes"
     #OBS_WORKER_TEST_MODE="yes"
 
+    ## Path:        Applications/OBS
+    ## Description: URL to a proxy service for caching binaries used by worker
+    ## Type:        string
+    ## Default:     ""
+    ## Config:      OBS
+    #
+    #
+    OBS_WORKER_BINARIES_PROXY="http://backend-other:5254"
+
 ---
 # Obs Worker Amd64 Deployment
 apiVersion: apps/v1

--- a/services/obs/worker/worker-test.yml
+++ b/services/obs/worker/worker-test.yml
@@ -639,6 +639,15 @@ data:
     #OBS_VM_USE_TMPFS="yes"
     #OBS_WORKER_TEST_MODE="yes"
 
+    ## Path:        Applications/OBS
+    ## Description: URL to a proxy service for caching binaries used by worker
+    ## Type:        string
+    ## Default:     ""
+    ## Config:      OBS
+    #
+    #
+    OBS_WORKER_BINARIES_PROXY="http://backend-test:5254"
+
 ---
 # Obs Worker Amd64 StatefulSet
 apiVersion: apps/v1


### PR DESCRIPTION
多个worker从backend下载构建软件包时会拖卡整个backend,在backend中添加单独的binary proxy服务解决这个问题，尤其是在obs因为大量的依赖更新（例如deepin:Develop:main批量rebuild完成后发布二进制更新）导致大量的包需要rebuild时，会出现worker下载二进制软件包洪峰现象，然后拖卡整个obs backend