### PR TITLE
prow: update config for tide

### DIFF
--- a/services/prow/config/config.yml
+++ b/services/prow/config/config.yml
@@ -220,6 +220,8 @@ tide:
     peeweep-test: rebase
     deepin-community: rebase
     linuxdeepin: rebase
+  context_options:
+    skip-unknown-contexts: true
 obscijobs:
   - repos:
       - linuxdeepin


### PR DESCRIPTION
github api接口更新，可以查询到github action的状态，导致tide判断部分skip掉的github action为非成功状态，因此阻塞了tide的代码合并 目前先暂时开启skip-unknown-contexts解决这种情况，后续通过上游提patch修复