### PR TITLE
安全加固

### DIFF
--- a/services/obs/api/api-local.yml
+++ b/services/obs/api/api-local.yml
@@ -240,6 +240,62 @@ metadata:
   name: api-local-options-config
   namespace: obs
 
+# Obs Local Api Db Config
+---
+apiVersion: v1
+data:
+  database.yml: |
+    # MySQL (default setup).  Versions 4.1 and 5.0 are recommended.
+    #
+    # Get the fast C bindings:
+    #   gem install mysql
+    #   (on OS X: gem install mysql -- --include=/usr/local/lib)
+    # And be sure to use new-style password hashing:
+    #   http://dev.mysql.com/doc/refman/5.0/en/old-client.html
+
+    production:
+      adapter: mysql2
+      database: api_production
+      username: *
+      password: *
+      encoding: utf8mb4
+      collation: utf8mb4_unicode_ci
+      host: 10.20.64.41
+      port: 3306
+      timeout: 15
+      pool: 30
+
+    development:
+      adapter: mysql2
+      database: api_development
+      username: obs
+      password: obs
+      encoding: utf8mb4
+      collation: utf8mb4_unicode_ci
+      host: 172.25.6.1
+      port: 3306
+      timeout: 15
+      pool: 30
+
+    # Warning: The database defined as 'test' will be erased and
+    # re-generated from your development database when you run 'rails'.
+    # Do not set this db to the same as development or production.
+    test:
+      adapter: mysql2
+      database: api_test
+      username: obs
+      password: obs
+      encoding: utf8mb4
+      collation: utf8mb4_unicode_ci
+      host: 172.25.6.1
+      port: 3306
+      timeout: 15
+      pool: 30
+kind: ConfigMap
+metadata:
+  name: api-local-db-config
+  namespace: obs
+
 # Obs Api Deployment
 ---
 apiVersion: apps/v1
@@ -313,8 +369,8 @@ spec:
             items:
               - key: database.yml
                 path: database.yml
-            name: api-db-config
-          name: api-db-config
+            name: api-local-db-config
+          name: api-local-db-config
         - configMap:
             defaultMode: 420
             items:

--- a/services/obs/obs-cluster.yml
+++ b/services/obs/obs-cluster.yml
@@ -1579,6 +1579,7 @@ data:
     # OBS WEBUI & API
     <VirtualHost *:31443>
             ServerName build-test.deepin.com
+            TraceEnable off
             # ServerName build.deepin.com
             # ServerName localhost
 

--- a/services/obs/obs-cluster.yml
+++ b/services/obs/obs-cluster.yml
@@ -1969,8 +1969,28 @@ spec:
         app: api
     spec:
       containers:
+        - env:
+            - name: MYSQL_ROOT_PASSWORD
+              value: obs
+            - name: TIME_ZONE
+              value: Asia/Shanghai
+          image: 'mariadb:10.6.14'
+          imagePullPolicy: IfNotPresent
+          name: mysql
+          ports:
+            - containerPort: 3306
+              name: mysql
+              protocol: TCP
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /etc/mysql/conf.d
+              name: db-config-data
+            - mountPath: /var/lib/mysql
+              name: db-data
         - image: 'memcached:latest'
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           name: memcached
           ports:
             - containerPort: 11211
@@ -1978,12 +1998,13 @@ spec:
           resources: {}
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
-        - image: 'hub.deepin.com/k3s/obs/api:latest'
+        - image: 'hub.deepin.com/k3s/obs/api:test'
           imagePullPolicy: Always
           name: api
           ports:
             - containerPort: 31443
               protocol: TCP
+          resources: {}
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:
@@ -1996,6 +2017,10 @@ spec:
             - mountPath: /srv/www/obs/api/config/options.yml
               name: api-options-config
               subPath: options.yml
+            - mountPath: /srv/www/obs/docs/api/obs.rng
+              name: linglong-obsrng
+              readOnly: true
+              subPath: obs.rng
       dnsConfig:
         nameservers:
           - 114.114.114.114
@@ -2035,6 +2060,18 @@ spec:
                 path: options.yml
             name: api-options-config
           name: api-options-config
+        - configMap:
+            defaultMode: 420
+            name: apiserver-linglong-patch
+          name: linglong-obsrng
+        - configMap:
+            defaultMode: 420
+            name: mariadb-config
+          name: db-config-data
+        - hostPath:
+            path: /srv/mysql
+            type: DirectoryOrCreate
+          name: db-data
 
 # Obs Api Service
 ---
@@ -2082,6 +2119,31 @@ spec:
       port: 11211
       protocol: TCP
       targetPort: 11211
+  selector:
+    app: api
+  sessionAffinity: None
+  type: ClusterIP
+
+# Obs mysql Service
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {}
+  labels:
+    app: api
+  name: mysql
+  namespace: obs
+spec:
+  internalTrafficPolicy: Cluster
+  ipFamilies:
+    - IPv4
+  ipFamilyPolicy: SingleStack
+  ports:
+    - name: mysql
+      port: 3306
+      protocol: TCP
+      targetPort: 3306
   selector:
     app: api
   sessionAffinity: None


### PR DESCRIPTION
1. mysql迁移到集群，关闭外网端口访问，切换到集群内网访问，提升安全性
2. 内网obs web同样切换到集群内mysql访问
3. 关闭obs web服务的trace,提升web访问安全性
