### PR TITLE
prow: Update config for deepin-unioncode

### DIFF
--- a/services/prow/config/config.yml
+++ b/services/prow/config/config.yml
@@ -220,6 +220,7 @@ tide:
     peeweep-test: rebase
     deepin-community: rebase
     linuxdeepin: rebase
+    linuxdeepin/deepin-unioncode: merge
 obscijobs:
   - repos:
       - linuxdeepin


### PR DESCRIPTION
合并方式改为merge,开发人员的习惯分支合并方式为merge,因此修改配置