### PR TITLE
prow: ghc package jobs

### DIFF
--- a/services/prow/config/jobs/images/ghc-packages-obsci/Dockerfile
+++ b/services/prow/config/jobs/images/ghc-packages-obsci/Dockerfile
@@ -1,0 +1,23 @@
+# 使用debian:latest作为基础镜像
+FROM hub.cicd.getdeepin.org/library/debian:stable-slim
+
+ENV container k3s
+
+# 设置维护者信息
+LABEL maintainer="hudeng@deepin.org"
+
+# 更换清华源
+RUN sed -i 's/deb.debian.org/mirrors.tuna.tsinghua.edu.cn/g' /etc/apt/sources.list.d/debian.sources \
+    && sed -i 's/security.debian.org/mirrors.tuna.tsinghua.edu.cn\/debian-security/g' /etc/apt/sources.list.d/debian.sources
+
+# 更新源并安装pkg-haskell-tools
+RUN apt update && apt install -y curl pkg-haskell-tools jq osc && apt clean
+RUN mkdir -p /work/ghc
+
+# 配置工作目录
+WORKDIR /work/ghc
+
+
+ADD entrypoint.sh /entrypoint.sh
+
+RUN chmod 0755 /entrypoint.sh

--- a/services/prow/config/jobs/images/ghc-packages-obsci/entrypoint.sh
+++ b/services/prow/config/jobs/images/ghc-packages-obsci/entrypoint.sh
@@ -1,0 +1,118 @@
+#!/bin/sh
+#set -x
+
+# 导入yq命令
+command -v curl >/dev/null 2>&1 || { echo >&2 "curl命令未找到，请先安装curl命令"; exit 1; }
+command -v git >/dev/null 2>&1 || { echo >&2 "git命令未找到，请先安装git命令"; exit 1; }
+command -v jq >/dev/null 2>&1 || { echo >&2 "jq命令未找到，请先安装jq命令"; exit 1; }
+command -v dht >/dev/null 2>&1 || { echo >&2 "dht命令未找到，请先安装dht命令"; exit 1; }
+
+#export
+
+# 检查Obs账户配置
+if [ -z "$OSCUSER" ]; then
+    echo "OBS User missing, exit"
+    exit -1
+fi
+
+if [ -z "$OSCPASS" ]; then
+    echo "OBS Password missing, exit"
+    exit -1
+fi
+
+if [ -z "$OBS_HOST" ]; then
+    echo "OBS Host missing, exit"
+    exit -1
+fi
+
+if [ -z "$REPO_OWNER" ]; then
+    export REPO_OWNER="deepin-community"
+fi
+
+if [ -z "$REPO_NAME" ]; then
+    export REPO_NAME="GHC_packages"
+fi
+
+if [ -z "$PULL_NUMBER" ]; then
+    export PULL_NUMBER="1"
+fi
+
+if [ -z "$PULL_PULL_SHA" ]; then
+    export PULL_PULL_SHA="ce334a4f31b85af6ca85bc1e1819dc89a6bd51fc"
+fi
+
+if [ -z "$PULL_HEAD_REF" ]; then
+    export PULL_HEAD_REF="deepin-main"
+fi
+
+export full_repo_name="$REPO_OWNER/$REPO_NAME"
+
+PROJECT_NAME="$REPO_OWNER:$REPO_NAME:PR-$PULL_NUMBER"
+if [[ "$PULL_HEAD_REF" == "topic-"* ]]; then
+    prefix="topic-"
+    topic=${PULL_HEAD_REF#$prefix}
+    echo "Add to topic to $topic"
+    PROJECT_NAME="topics:$topic"
+fi
+
+# 创建obs pr project
+cat > ${PROJECT_NAME}.xml << EOF
+<project name="deepin:CI:${PROJECT_NAME}">
+  <title/>
+  <description/>
+  <person userid="deepin-obs" role="maintainer"/>
+  <repository name="deepin_develop">
+    <path project="deepin:CI" repository="ghc"/>
+    <arch>aarch64</arch>
+    <arch>riscv64</arch>
+    <arch>x86_64</arch>
+    <arch>i386</arch>
+    <arch>loong64</arch>
+  </repository>
+</project>
+EOF
+osc api -X PUT -f ${PROJECT_NAME}.xml /source/deepin:CI:${PROJECT_NAME}/_meta
+
+# 获取pr的文件列表
+packages=$(curl -L \
+  -H "Accept: application/vnd.github+json" \
+  -H "Authorization: Bearer $GITHUB_TOKEN" \
+  -H "X-GitHub-Api-Version: 2022-11-28" \
+  https://api.github.com/repos/$full_repo_name/pulls/$PULL_NUMBER/files \
+  | jq '.[] | .filename' | grep p/ | awk -F '/' '{print $2}'|sort|uniq)
+
+# git clone ghc packages debian目录管理项目
+git clone --filter=blob:none --no-checkout https://github.com/$full_repo_name
+cd $REPO_NAME
+
+for p in $packages
+do
+    echo ${p} updating
+    git checkout $PULL_PULL_SHA -- p/${p}
+    dht debian2dsc -o p/${p} p/${p}/debian
+    osc api -X PUT -f ${p}.xml /source/deepin:CI:${PROJECT_NAME}/${p}/_meta
+    for d in $(osc ls deepin:CI:${PROJECT_NAME}/${p})
+    do
+        echo "delete ${p}'s ${d}"
+        osc api -X DELETE /source/deepin:CI:${PROJECT_NAME}/${p}/${d}
+    done
+    for f in $(ls p/${p})
+    do
+        cat > ${p}.xml << EOF
+<package name="${p}" project="deepin:CI:${PROJECT_NAME}">
+  <title/>
+  <description/>
+</package>
+EOF
+        if [ "$f" != "debian" ];then
+            osc api -X PUT -f p/${p}/${f} /source/deepin:CI:${PROJECT_NAME}/${p}/${f}
+        fi
+    done
+
+    # 添加pending状态
+    for arch in $(echo 'aarch64 x86_64 loong64 i386 riscv64')
+    do
+        echo "{\"state\":\"pending\", \"context\":\"OBS: ${p}/${arch}\", \"target_url\":\"https://build.deepin.com/package/live_build_log/deepin:CI:${PROJECT_NAME}/${p}/deepin_develop/${arch}\"}" > status.data
+        curl -X POST -H "Accept: application/vnd.github+json" -H "Authorization: token $GITHUB_TOKEN" -d @status.data https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/statuses/${PULL_PULL_SHA}
+    done
+done

--- a/services/prow/config/jobs/images/ghc-packages-obssync/Dockerfile
+++ b/services/prow/config/jobs/images/ghc-packages-obssync/Dockerfile
@@ -1,0 +1,23 @@
+# 使用debian:latest作为基础镜像
+FROM hub.cicd.getdeepin.org/library/debian:stable-slim
+
+ENV container k3s
+
+# 设置维护者信息
+LABEL maintainer="hudeng@deepin.org"
+
+# 更换清华源
+RUN sed -i 's/deb.debian.org/mirrors.tuna.tsinghua.edu.cn/g' /etc/apt/sources.list.d/debian.sources \
+    && sed -i 's/security.debian.org/mirrors.tuna.tsinghua.edu.cn\/debian-security/g' /etc/apt/sources.list.d/debian.sources
+
+# 更新源并安装pkg-haskell-tools
+RUN apt update && apt install -y curl pkg-haskell-tools jq osc && apt clean
+RUN mkdir -p /work/ghc
+
+# 配置工作目录
+WORKDIR /work/ghc
+
+
+ADD entrypoint.sh /entrypoint.sh
+
+RUN chmod 0755 /entrypoint.sh

--- a/services/prow/config/jobs/images/ghc-packages-obssync/entrypoint.sh
+++ b/services/prow/config/jobs/images/ghc-packages-obssync/entrypoint.sh
@@ -1,0 +1,89 @@
+#!/bin/sh
+#set -x
+
+# 导入yq命令
+command -v curl >/dev/null 2>&1 || { echo >&2 "curl命令未找到，请先安装curl命令"; exit 1; }
+command -v git >/dev/null 2>&1 || { echo >&2 "git命令未找到，请先安装git命令"; exit 1; }
+command -v jq >/dev/null 2>&1 || { echo >&2 "jq命令未找到，请先安装jq命令"; exit 1; }
+command -v dht >/dev/null 2>&1 || { echo >&2 "dht命令未找到，请先安装dht命令"; exit 1; }
+
+#export
+
+# 检查Obs账户配置
+if [ -z "$OSCUSER" ]; then
+    echo "OBS User missing, exit"
+    exit -1
+fi
+
+if [ -z "$OSCPASS" ]; then
+    echo "OBS Password missing, exit"
+    exit -1
+fi
+
+if [ -z "$OBS_HOST" ]; then
+    echo "OBS Host missing, exit"
+    exit -1
+fi
+
+if [ -z "$REPO_OWNER" ]; then
+    export REPO_OWNER="deepin-community"
+fi
+
+if [ -z "$REPO_NAME" ]; then
+    export REPO_NAME="GHC_packages"
+fi
+
+if [ -z "$PULL_BASE_SHA" ]; then
+    export PULL_BASE_SHA="ce334a4f31b85af6ca85bc1e1819dc89a6bd51fc"
+fi
+
+export full_repo_name="$REPO_OWNER/$REPO_NAME"
+
+# 获取pr number
+PULL_NUMBER=$(curl -L \
+  -H "Accept: application/vnd.github+json" \
+  -H "Authorization: Bearer $GITHUB_TOKEN" \
+  -H "X-GitHub-Api-Version: 2022-11-28" \
+  https://api.github.com/repos/$full_repo_name/commits/$PULL_BASE_SHA/pulls \
+  | jq '.[] | .number')
+
+# 获取pr的文件列表
+packages=$(curl -L \
+  -H "Accept: application/vnd.github+json" \
+  -H "Authorization: Bearer $GITHUB_TOKEN" \
+  -H "X-GitHub-Api-Version: 2022-11-28" \
+  https://api.github.com/repos/$full_repo_name/pulls/$PULL_NUMBER/files \
+  | jq '.[] | .filename' | grep p/ | awk -F '/' '{print $2}'|sort|uniq)
+
+# git clone ghc packages debian目录管理项目
+git clone --filter=blob:none --no-checkout https://github.com/$full_repo_name
+cd $REPO_NAME
+
+for p in $packages
+do
+    echo ${p} updating
+    git checkout deepin-main -- p/${p}
+    dht debian2dsc -o p/${p} p/${p}/debian
+    osc api -X PUT -f ${p}.xml /source/ghc:exp/${p}/_meta
+    for d in $(osc ls ghc:exp/${p})
+    do
+        echo "delete ${p}'s ${d}"
+        osc api -X DELETE /source/ghc:exp/${p}/${d}
+    done
+    for f in $(ls p/${p})
+    do
+        cat > ${p}.xml << EOF
+<package name="${p}" project="ghc:exp">
+  <title/>
+  <description/>
+</package>
+EOF
+        if [ "$f" != "debian" ];then
+            osc api -X PUT -f p/${p}/${f} /source/ghc:exp/${p}/${f}
+        fi
+    done
+
+    # 添加success状态
+    echo "{\"state\":\"success\", \"context\":\"OBS: ${p} sync\", \"target_url\":\"https://build.deepin.com/package/show/ghc:exp/${p}\"}" > status.data
+    curl -X POST -H "Accept: application/vnd.github+json" -H "Authorization: token $GITHUB_TOKEN" -d @status.data https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/statuses/${PULL_BASE_SHA}
+done

--- a/services/prow/config/jobs/submits.yml
+++ b/services/prow/config/jobs/submits.yml
@@ -369,6 +369,179 @@ hold-version-check: &hold-version-check
       Runs Prow hold-version-check to config and trigger obs ci, and use canal
       return obs ci build job status.
 
+ghc-packages-obs-ci: &ghc-packages-obs-ci
+  name: ghc-packages-obs-ci
+  decorate: false
+  always_run: false
+  skip_if_only_changed: ^.github/|^.obs/|^.reuse/|\.(md|adoc)$|^(README|LICENSE)$
+  labels:
+    app: ghc-packages-obs-ci
+  spec:
+    nodeSelector:
+      kubernetes.io/arch: amd64
+    hostAliases:
+      - ip: 10.20.64.81
+        hostnames:
+          - github.com
+      - ip: 10.20.64.82
+        hostnames:
+          - api.github.com
+      - ip: 10.20.64.83
+        hostnames:
+          - github.githubassets.com
+      - ip: 10.20.64.84
+        hostnames:
+          - raw.githubusercontent.com
+      - ip: 10.20.64.85
+        hostnames:
+          - collector.github.com
+      - ip: 10.20.64.86
+        hostnames:
+          - avatars.githubusercontent.com
+      - ip: 8.136.204.218
+        hostnames:
+          - build.deepin.com
+      - ip: 10.20.64.81
+        hostnames:
+          - hackage.haskell.org
+    containers:
+      - name: ghc-packages-obs-ci
+        image: "hub.deepin.com/prow/ghcpackagesobsci:latest"
+        command:
+          - /entrypoint.sh
+        env:
+          - name: OSCUSER
+            valueFrom:
+              secretKeyRef:
+                name: obs-api-credential
+                key: username
+          - name: OSCPASS
+            valueFrom:
+              secretKeyRef:
+                name: obs-api-credential
+                key: password
+          - name: GITHUB_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: obs-api-credential
+                key: github-token
+          - name: OBS_HOST
+            valueFrom:
+              secretKeyRef:
+                name: obs-api-credential
+                key: obs-host
+          - name: CONFIG_YAML_FILE
+            value: /etc/config/config.yaml
+        volumeMounts:
+          - name: github-token
+            mountPath: /etc/github
+            readOnly: true
+          - name: config
+            mountPath: /etc/config
+            readOnly: true
+    volumes:
+      - name: github-token
+        secret:
+          secretName: github-token
+      - name: config
+        configMap:
+          name: config
+  annotations:
+    testgrid-num-failures-to-alert: "6"
+    testgrid-alert-stale-results-hours: "12"
+    testgrid-dashboards: sig-deepin-cicd
+    testgrid-tab-name: ghc-packages-obs-ci
+    testgrid-alert-email: hudeng@deepin.org
+    description: >-
+      Runs Prow ghc-packages-obs-ci to config and trigger ghc obs ci, and use canal
+      return obs ci build job status.
+
+ghc-packages-obs-sync: &ghc-packages-obs-sync
+  name: ghc-packages-obs-sync
+  decorate: false
+  always_run: false
+  skip_if_only_changed: ^.github/|^.obs/|^.reuse/|\.(md|adoc)$|^(README|LICENSE)$
+  labels:
+    app: ghc-packages-obs-sync
+  spec:
+    nodeSelector:
+      kubernetes.io/arch: amd64
+    hostAliases:
+      - ip: 10.20.64.81
+        hostnames:
+          - github.com
+      - ip: 10.20.64.82
+        hostnames:
+          - api.github.com
+      - ip: 10.20.64.83
+        hostnames:
+          - github.githubassets.com
+      - ip: 10.20.64.84
+        hostnames:
+          - raw.githubusercontent.com
+      - ip: 10.20.64.85
+        hostnames:
+          - collector.github.com
+      - ip: 10.20.64.86
+        hostnames:
+          - avatars.githubusercontent.com
+      - ip: 8.136.204.218
+        hostnames:
+          - build.deepin.com
+      - ip: 10.20.64.81
+        hostnames:
+          - hackage.haskell.org
+    containers:
+      - name: ghc-packages-obs-sync
+        image: "hub.deepin.com/prow/ghcpackagesobssync:latest"
+        command:
+          - /entrypoint.sh
+        env:
+          - name: OSCUSER
+            valueFrom:
+              secretKeyRef:
+                name: obs-api-credential
+                key: username
+          - name: OSCPASS
+            valueFrom:
+              secretKeyRef:
+                name: obs-api-credential
+                key: password
+          - name: GITHUB_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: obs-api-credential
+                key: github-token
+          - name: OBS_HOST
+            valueFrom:
+              secretKeyRef:
+                name: obs-api-credential
+                key: obs-host
+          - name: CONFIG_YAML_FILE
+            value: /etc/config/config.yaml
+        volumeMounts:
+          - name: github-token
+            mountPath: /etc/github
+            readOnly: true
+          - name: config
+            mountPath: /etc/config
+            readOnly: true
+    volumes:
+      - name: github-token
+        secret:
+          secretName: github-token
+      - name: config
+        configMap:
+          name: config
+  annotations:
+    testgrid-num-failures-to-alert: "6"
+    testgrid-alert-stale-results-hours: "12"
+    testgrid-dashboards: sig-deepin-cicd
+    testgrid-tab-name: ghc-packages-obs-sync
+    testgrid-alert-email: hudeng@deepin.org
+    description: >-
+      Runs Prow ghc-packages-obs-sync to sync obs ghc:exp.
+
 presubmits:
   peeweep-test:
     - <<: *github-trigger-obs-ci
@@ -395,6 +568,8 @@ presubmits:
     - <<: *github-pr-review-ci
   linuxdeepin/treeland.private:
     - <<: *github-trigger-obs-ci
+  deepin-community/GHC_packages:
+    - <<: *ghc-packages-obs-ci
 
 postsubmits:
   deepin-community:
@@ -424,3 +599,5 @@ postsubmits:
   linuxdeepin/treeland.private:
     - <<: *obs-src-sync
     - <<: *linuxdeepin-sync-to-gitlab
+  deepin-community/GHC_packages:
+  - <<: *ghc-packages-obs-sync


### PR DESCRIPTION
使用https://github.com/deepin-community/GHC_packages 维护ghc相关包，因此添加这个项目的prow 任务，实现更新ghc的某个包的debian目录就使用dht工具下载源码然后在obs上构建。