### PR TITLE
registry-proxy: Add exclude namespace for self

### DIFF
--- a/services/registry-proxy/apply.sh
+++ b/services/registry-proxy/apply.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 kubectl create namespace registry-proxy
-kubectl apply -f manifests.yaml
 kubectl apply -f registry-proxy-config.yaml
+kubectl apply -f manifests.yaml

--- a/services/registry-proxy/registry-proxy-config.yaml
+++ b/services/registry-proxy/registry-proxy-config.yaml
@@ -16,6 +16,9 @@ data:
         quay.io: quay.cicd.getdeepin.org
         registry.k8s.io: k8s-registry.cicd.getdeepin.org
         hub.deepin.com: deepinhub.cicd.getdeepin.org
+    excludeNamespaces:
+        - "registry-proxy"
+        - "default"
     includeNamespaces:
         - '*'
     includeRegistries:


### PR DESCRIPTION
registry-porxy本是不能被代理,否则会出现嵌套,一旦自身出现问题就无法正常重启,同时影响其他的镜像代理正常运行