### PR TITLE
prow: fix deepin-auto-translation job error

### DIFF
--- a/services/prow/config/jobs/submits.yml
+++ b/services/prow/config/jobs/submits.yml
@@ -341,7 +341,7 @@ deepin-auto-translation: &deepin-auto-translation
   decoration_config:
     timeout: 240m
   always_run: true
-  run_if_changed: ".ts$"
+  run_if_changed: '\.ts$'
   labels:
     app: deepin-auto-translation
   spec:


### PR DESCRIPTION
单引号的方式处理包含'.'的则正，才能正确匹配