### PR TITLE
obs: api service disable archlinux build pending status support

### DIFF
--- a/services/obs/api/patches/0002-feat-workflow-build-job-add-pending-status-support.patch
+++ b/services/obs/api/patches/0002-feat-workflow-build-job-add-pending-status-support.patch
@@ -43,7 +43,7 @@ index 6a8424a972..3de5e10b16 100644
 +            payload['arch'] = arch
 +            payload['project'] = step.target_project_name
 +            payload['package'] = package
-+            SCMStatusReporter.new(payload, payload, scm_token, workflow_run, 'pending', initial_report: false).call if not name.include?("debian")
++            SCMStatusReporter.new(payload, payload, scm_token, workflow_run, 'pending', initial_report: false).call if !name.include?("debian") && !name.include?("archlinux")
 +          end
 +        end
 +      end


### PR DESCRIPTION
目前archlinux在obs环境下无法用最新版的包管理工具装包，因此无法编译