### PR TITLE
chore: Remove obsolete OBS CI configs for treeland projects

### DIFF
--- a/services/prow/config/config.yml
+++ b/services/prow/config/config.yml
@@ -309,6 +309,8 @@ obscijobs:
       - deepin-community/.blog.deepin.org
       - deepin-community/infra-settings
       - deepin-community/deepin-chatopt-script
+      - linuxdeepin/ddm
+      - linuxdeepin/treeland
   - repos:
       - linuxdeepin/deepin-osconfig
     project_config: |
@@ -411,38 +413,3 @@ obscijobs:
           <param name="versionformat">@CHANGELOG@@DEEPIN_OFFSET@</param>
         </service>
       </services>
-  - repos:
-      - linuxdeepin/treeland.private
-    project_meta_tpl: |
-      <project name="deepin:CI:PROJECT_NAME">
-        <title/>
-        <description/>
-        <sourceaccess>
-          <disable/>
-        </sourceaccess>
-        <access>
-          <disable/>
-        </access>
-        <repository name="deepin_ci">
-          <path project="vioken" repository="deepin_develop"/>
-          <arch>x86_64</arch>
-          <arch>aarch64</arch>
-        </repository>
-      </project>
-    package_meta_tpl: |
-      <package name="PKGNAME" project="deepin:CI:PROJECT_NAME">
-        <title/>
-        <description/>
-      </package>
-    project_service_tpl: |
-      <services>
-        <service name="obs_gbp">
-          <param name="url">git@github.com:linuxdeepin/treeland.private.git</param>
-          <param name="scm">git</param>
-          <param name="exclude">.git</param>
-          <param name="exclude">.github</param>
-          <param name="versionformat">@CHANGELOG@@DEEPIN_OFFSET@</param>
-        </service>
-      </services>
-    build_script: |
-      exec dpkg-buildpackage -us -uc --build=any,all "$@"

--- a/services/prow/config/jobs/images/obsci/test.yml
+++ b/services/prow/config/jobs/images/obsci/test.yml
@@ -34,6 +34,8 @@ obscijobs:
     </services>
   excluderepos:
     - linuxdeepin/dt
+    - linuxdeepin/ddm
+    - linuxdeepin/treeland
 - repos:
   - hudeng-go
   project_config: |
@@ -62,38 +64,3 @@ obscijobs:
     </services>
   excluderepos:
     - hudeng-go/test
-- repos:
-    - linuxdeepin/treeland.private
-  project_meta_tpl: |
-    <project name="deepin:CI:PROJECT_NAME">
-      <title/>
-      <description/>
-      <sourceaccess>
-        <disable/>
-      </sourceaccess>
-      <access>
-        <disable/>
-      </access>
-      <repository name="deepin_ci">
-        <path project="vioken" repository="deepin_develop"/>
-        <arch>x86_64</arch>
-        <arch>aarch64</arch>
-      </repository>
-    </project>
-  package_meta_tpl: |
-    <package name="PKGNAME" project="deepin:CI:PROJECT_NAME">
-      <title/>
-      <description/>
-    </package>
-  project_service_tpl: |
-    <services>
-      <service name="obs_gbp">
-        <param name="url">git@github.com:linuxdeepin/treeland.private.git</param>
-        <param name="scm">git</param>
-        <param name="exclude">.git</param>
-        <param name="exclude">.github</param>
-        <param name="versionformat">@CHANGELOG@@DEEPIN_OFFSET@</param>
-      </service>
-    </services>
-  build_script: |
-    exec dpkg-buildpackage -us -uc --build=any,all "$@"

--- a/services/prow/config/jobs/submits.yml
+++ b/services/prow/config/jobs/submits.yml
@@ -954,8 +954,6 @@ presubmits:
   linuxdeepin:
     - <<: *github-pr-review-ci
     - <<: *deepin-auto-translation
-  linuxdeepin/treeland.private:
-    - <<: *github-trigger-obs-ci
   deepin-community/GHC_packages:
     - <<: *ghc-packages-obs-ci
 
@@ -985,9 +983,6 @@ postsubmits:
   linuxdeepin:
     - <<: *linuxdeepin-sync-to-gitlab
     - <<: *linuxdeepin-sync-to-gitee
-  linuxdeepin/treeland.private:
-    - <<: *obs-src-sync
-    - <<: *linuxdeepin-sync-to-gitlab
   deepin-community/GHC_packages:
     - <<: *ghc-packages-obs-sync
   OpenAtom-Linyaps:


### PR DESCRIPTION
Removed OBS CI configurations for `linuxdeepin/treeland.private` across `config.yml`, `jobs/images/obsci/test.yml`, and `jobs/submits.yml`. This project is no longer in use, making these configurations obsolete and invalid.

Additionally, `linuxdeepin/ddm` and `linuxdeepin/treeland` have been explicitly excluded from general OBS CI configurations. These projects now utilize dedicated GitHub Actions for their CI builds, rendering OBS CI unnecessary and redundant for them.

Influence:
1. Verify that `linuxdeepin/ddm` and `linuxdeepin/treeland` continue to build successfully via their GitHub Actions.
2. Confirm that no Prow jobs related to `linuxdeepin/treeland.private` are triggered or fail.
3. Observe reduced CI configuration complexity and resource usage related to these projects in Prow.

chore: 移除 treeland 项目过时的 OBS CI 配置

移除了 `config.yml`、`jobs/images/obsci/test.yml` 和 `jobs/submits.yml` 中针对 `linuxdeepin/treeland.private` 的 OBS CI 配置。该项目已不再使用， 因此相关配置已过时且无效。

此外，`linuxdeepin/ddm` 和 `linuxdeepin/treeland` 项目已被明确排除在通用 的 OBS CI 配置之外。这些项目现在使用专用的 GitHub Actions 进行 CI 构建， 因此 OBS CI 对它们来说已不再必要和冗余。

Influence:
1. 验证 `linuxdeepin/ddm` 和 `linuxdeepin/treeland` 项目通过其 GitHub Actions 能够继续成功构建。
2. 确认不再触发或因 `linuxdeepin/treeland.private` 相关的 Prow 作业而 失败。
3. 观察 Prow 中与这些项目相关的 CI 配置复杂性和资源使用